### PR TITLE
moved HALO specifics navigation data to function

### DIFF
--- a/scripts/navdata.py
+++ b/scripts/navdata.py
@@ -1,0 +1,40 @@
+# the individual loaders should import dependencies within the function
+# that way it is possible to run the code for one platform if dependencies
+# for another platform are not met
+
+_catalog_cache = {}
+
+def get_navdata_HALO(flight):
+    """
+    :param flight: flight id
+    """
+    import xarray as xr
+    from intake import open_catalog
+    if "HALO" not in _catalog_cache:
+        _catalog_cache["HALO"] = open_catalog("https://raw.githubusercontent.com/d70-t/eurec4a-intake/HALO_QL/catalog.yml")
+
+    catalog = _catalog_cache["HALO"]
+    bahamas = catalog.halo.bahamas.ql.by_flight_id[flight].to_dask()
+    ds = bahamas.rename({"tid": "time"})
+    return xr.Dataset({
+        "time": ds.TIME,
+        "lat": ds.IRS_LAT,
+        "lon": ds.IRS_LON,
+        "altitude": ds.IRS_ALT,
+        "roll": ds.IRS_PHI,
+        "pitch": ds.IRS_THE,
+        "heading": ds.IRS_HDG,
+    })
+
+NAVDATA_GETTERS = {
+    "HALO": get_navdata_HALO,
+}
+
+def get_navdata(platform, flight):
+    """
+    :param platform: platform id
+    :param flight: flight id
+    """
+    return NAVDATA_GETTERS[platform](flight)
+
+__all__ = ["get_navdata"]

--- a/scripts/navdata.py
+++ b/scripts/navdata.py
@@ -20,7 +20,7 @@ def get_navdata_HALO(flight):
         "time": ds.TIME,
         "lat": ds.IRS_LAT,
         "lon": ds.IRS_LON,
-        "altitude": ds.IRS_ALT,
+        "alt": ds.IRS_ALT,
         "roll": ds.IRS_PHI,
         "pitch": ds.IRS_THE,
         "heading": ds.IRS_HDG,

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -8,6 +8,8 @@ import matplotlib.gridspec as gridspec
 from io import BytesIO
 from base64 import b64encode
 
+from navdata import get_navdata
+
 border_time = np.timedelta64(3, "m")
 
 color_before = "C2"
@@ -33,11 +35,11 @@ def fig2data_url(fig):
     url = "data:{};base64,{}".format("image/png", b64.decode("ascii"))
     return url
 
-def start_end_lims(bahamas):
-    lat_min = min(*bahamas.lat.data[[0,-1]])
-    lat_max = max(*bahamas.lat.data[[0,-1]])
-    lon_min = min(*bahamas.lon.data[[0,-1]])
-    lon_max = max(*bahamas.lon.data[[0,-1]])
+def start_end_lims(navdata):
+    lat_min = min(*navdata.lat.data[[0,-1]])
+    lat_max = max(*navdata.lat.data[[0,-1]])
+    lon_min = min(*navdata.lon.data[[0,-1]])
+    lon_max = max(*navdata.lon.data[[0,-1]])
     delta = ((lat_max - lat_min) ** 2 + (lon_max - lon_min) ** 2)**.5
     lat_center = (lat_min + lat_max) / 2
     lon_center = (lon_min + lon_max) / 2
@@ -198,7 +200,7 @@ class SegmentChecker:
         self.used_segment_ids = set()
         self.flight_id = flight.get("flight_id", "")
 
-    def check_segment(self, seg, bahamas, sondes_by_flag):
+    def check_segment(self, seg, navdata, sondes_by_flag):
         if "segment_id" in seg:
             segment_id = seg["segment_id"]
             if not segment_id.startswith(self.flight_id):
@@ -283,14 +285,10 @@ def _main():
     parser = argparse.ArgumentParser()
     parser.add_argument("infile")
     parser.add_argument("outfile")
-    parser.add_argument("-d", "--data_path", default="../data")
     parser.add_argument("-s", "--sonde_info", help="sonde info yaml file", default=os.path.join(basedir, "sondes.yaml"))
     args = parser.parse_args()
 
     flightdata = yaml.load(open(args.infile), Loader=yaml.SafeLoader)
-    bahamas_path = os.path.join(args.data_path,
-                                "bahamas_{:%Y%m%d}_v0.4.nc".format(flightdata["date"]))
-    bahamas = xr.open_dataset(bahamas_path)
 
     global_warnings = []
     if "flight_id" in flightdata:
@@ -302,8 +300,7 @@ def _main():
     if "platform" in flightdata:
         platform = flightdata["platform"]
     else:
-        platform = "HALO"
-        global_warnings.append("platform is missing, assuming 'HALO'")
+        global_warnings.append("platform is missing")
 
     if args.sonde_info is not None:
         sonde_info = yaml.load(open(args.sonde_info), Loader=yaml.SafeLoader)
@@ -311,11 +308,13 @@ def _main():
         sonde_info = []
         global_warnings.append("no sonde_info is specified, using data from unified dataset")
 
+    navdata = get_navdata(platform, flight_id).load()
+
     sonde_info = [s for s in sonde_info if s["platform"] == platform]
     sondes_by_id = {s["sonde_id"]: s for s in sonde_info}
 
     fig, ax = plt.subplots()
-    ax.plot(bahamas.lon, bahamas.lat)
+    ax.plot(navdata.lon, navdata.lat)
     im = fig2data_url(fig)
     plt.close("all")
     flightdata["plot_data"] = im
@@ -325,9 +324,9 @@ def _main():
     for seg in flightdata["segments"]:
         t_start = np.datetime64(seg["start"])
         t_end = np.datetime64(seg["end"])
-        seg_bahamas = bahamas.sel(time=slice(t_start, t_end))
-        seg_before = bahamas.sel(time=slice(t_start - border_time, t_start))
-        seg_after = bahamas.sel(time=slice(t_end, t_end + border_time))
+        seg_navdata = navdata.sel(time=slice(t_start, t_end))
+        seg_before = navdata.sel(time=slice(t_start - border_time, t_start))
+        seg_after = navdata.sel(time=slice(t_end, t_end + border_time))
 
         sondes_in_segment = [s
                              for s in sonde_info
@@ -343,18 +342,18 @@ def _main():
         sonde_times = [s["launch_time"] for s in sondes_in_segment]
 
         sonde_tracks_by_flag = {
-            f: bahamas.sel(time=[s["launch_time"] for s in sondes], method="nearest")
+            f: navdata.sel(time=[s["launch_time"] for s in sondes], method="nearest")
             #for f, sondes in sondes_by_flag.items()
             for f, sondes in manual_sondes_by_flag.items()
         }
 
         plot_data = []
-        warnings = list(checker.check_segment(seg, seg_bahamas, sondes_by_flag))
+        warnings = list(checker.check_segment(seg, seg_navdata, sondes_by_flag))
 
         for plot in plots_for_kinds(seg.get("kinds", [])):
             try:
                 plot_data.append(fig2data_url(
-                    plot(seg_bahamas, sonde_tracks_by_flag, seg_before, seg_after)))
+                    plot(seg_navdata, sonde_tracks_by_flag, seg_before, seg_after)))
                 plt.close("all")
             except Exception as e:
                 warnings.append("plot could not be created: {}".format(e))
@@ -363,7 +362,7 @@ def _main():
         if len(sonde_times) > 0:
             seg["time_to_first_sonde"] = (np.datetime64(sonde_times[0]) - t_start) / np.timedelta64(1, "s")
         if kinds_is_circle(seg.get("kinds", [])):
-            seg["heading_difference"] = (seg_bahamas.heading.data[-1] - seg_bahamas.heading.data[0]) % 360
+            seg["heading_difference"] = (seg_navdata.heading.data[-1] - seg_navdata.heading.data[0]) % 360
 
         seg["warnings"] = warnings
 

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -70,7 +70,7 @@ def default_segment_plot(seg, sonde_tracks_by_flag, seg_before, seg_after):
     overview_ax.set_xlabel("longitude [deg]")
     overview_ax.set_ylabel("latitude [deg]")
 
-    for ax, var, unit in [(alt_ax, "altitude", "m"),
+    for ax, var, unit in [(alt_ax, "alt", "m"),
                           (roll_ax, "roll", "deg"),
                           (pitch_ax, "pitch", "deg"),
                           (yaw_ax, "heading", "deg")]:
@@ -175,11 +175,11 @@ SPECIAL_PLOTS = {
     "circle": [circle_detail_plot, zoom_on("roll", "deg")],
     "circling": [zoom_on("roll", "deg", tofs=np.timedelta64(3, "m")),
                  zoom_on("pitch", "deg", tofs=np.timedelta64(3, "m")),
-                 zoom_on("altitude", "m", tofs=np.timedelta64(3, "m"))],
+                 zoom_on("alt", "m", tofs=np.timedelta64(3, "m"))],
     "straight_leg": [straight_leg_detail_plot, zoom_on("roll", "deg")],
     "radar_calibration_wiggle": [zoom_on("roll", "deg")],
     "radar_calibration_tilted": [zoom_on("roll", "deg")],
-    "lidar_leg": [timeline_of("altitude", "m"), zoom_on("altitude", "m")],
+    "lidar_leg": [timeline_of("alt", "m"), zoom_on("alt", "m")],
     "baccardi_calibration": [straight_leg_detail_plot, zoom_on("roll", "deg")],
 }
 


### PR DESCRIPTION
In order to support multiple platforms, specific code of loading platform navigation data should be factored out to specific functions. These can be collected in navdata.py. Dispatching to the correct function is done based on the `platform` attribute of each flight.

This PR should help with #3 and also includes a method to obtain HALO flight data from Aeris via opendap.