### PR TITLE
added compiled_release workflow

### DIFF
--- a/.github/workflows/compiled_release.yml
+++ b/.github/workflows/compiled_release.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+      - name: Compile all flight segment files into one yaml file
+        run: |
+          cd scripts
+          python compile.py ../flight_phase_files/*/*.yaml -o ../all_flights.yaml
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./all_flights.yaml
+          asset_name: all_flights.yaml
+          asset_content_type: text/yaml

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -1,0 +1,31 @@
+import sys
+import yaml
+from collections import defaultdict
+
+def _main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("infiles", type=str, nargs="+")
+    parser.add_argument("-o", "--outfile", type=str)
+
+    args = parser.parse_args()
+
+    all_flights = defaultdict(dict)
+
+    for filename in args.infiles:
+        with open(filename) as f:
+            flight = yaml.load(f, Loader=yaml.SafeLoader)
+        all_flights[flight["platform"]][flight["flight_id"]] = flight
+
+    if args.outfile:
+        outfile = open(args.outfile, "w")
+    else:
+        outfile = sys.stdout
+
+    yaml.dump(dict(all_flights.items()), outfile)
+
+    return 0
+
+if __name__ == "__main__":
+    exit(_main())

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -2,6 +2,7 @@ import sys
 import yaml
 from collections import defaultdict
 
+
 def _main():
     import argparse
 
@@ -26,6 +27,7 @@ def _main():
     yaml.dump(dict(all_flights.items()), outfile)
 
     return 0
+
 
 if __name__ == "__main__":
     exit(_main())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+# for reading the files
+pyyaml


### PR DESCRIPTION
This workflow creates a release with one compiled flight segment file for all flights. There is an example release [v1.0.1-rc1](https://github.com/eurec4a/flight-phase-separation/releases/tag/v1.0.1-rc1) which contains a compiled [all_flights.yaml](https://github.com/eurec4a/flight-phase-separation/releases/download/v1.0.1-rc1/all_flights.yaml).

Having one file including all segments of all flights and aircraft simplifies downloading of the respective metadata and allows to enumerate flights.