### PR TITLE
Minor correction to report.py

### DIFF
--- a/scripts/report.py
+++ b/scripts/report.py
@@ -336,7 +336,7 @@ def _main():
         sondes_by_flag = {f: [s for s in sondes_in_segment if s["flag"] == f]
                           for f in set(s["flag"] for s in sondes_in_segment)}
 
-        manual_sondes_by_flag = {f: [sondes_by_id[s] for s in sondes] for f, sondes in seg.get("dropsondes", []).items()}
+        manual_sondes_by_flag = {f: [sondes_by_id[s] for s in sondes] for f, sondes in seg.get("dropsondes", {}).items()}
 
         seg["sondes_by_flag"] = sondes_by_flag
 


### PR DESCRIPTION
I had to make this small change to get report.py to work with twinotter yaml files where the dropsonde attribute is absent. Thought I should get it in before I add more things in for the twinotter data so people don't end up making the same fix.

I can't run the HALO data through it so just check this is what was originally intended.