### PR TITLE
Twin Otter yaml files

### DIFF
--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124a_0.1.yaml
@@ -1,0 +1,133 @@
+name: RF01
+mission: EUREC4A
+platform: TO
+flight_id: TO-0330
+contacts: []
+date: 2020-01-24
+flight_report: ''
+takeoff: 2020-01-24 11:06:37
+landing: 2020-01-24 14:02:53
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 11:25:13
+  end: 2020-01-24 11:34:58
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 11:34:58
+  end: 2020-01-24 11:45:28
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 11:45:28
+  end: 2020-01-24 11:50:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 11:50:21
+  end: 2020-01-24 12:01:37
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 12:02:44
+  end: 2020-01-24 12:18:52
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 12:17:45
+  end: 2020-01-24 12:27:53
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 12:28:15
+  end: 2020-01-24 12:42:53
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 12:47:24
+  end: 2020-01-24 12:54:09
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 12:56:46
+  end: 2020-01-24 13:06:09
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:06:09
+  end: 2020-01-24 13:08:24
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:08:47
+  end: 2020-01-24 13:12:32
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:17:47
+  end: 2020-01-24 13:29:03
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:32:03
+  end: 2020-01-24 13:36:11
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:36:33
+  end: 2020-01-24 13:43:41
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:44:03
+  end: 2020-01-24 13:47:26
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:47:49
+  end: 2020-01-24 13:56:04
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0330_
+  start: 2020-01-24 13:59:27
+  end: 2020-01-24 14:01:42

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124a_0.1.yaml
@@ -9,125 +9,143 @@ takeoff: 2020-01-24 11:06:37
 landing: 2020-01-24 14:02:53
 events: []
 remarks:
+- Calibration flight
 - HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
   or H2O_LICOR.
 segments:
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_a
   start: 2020-01-24 11:25:13
   end: 2020-01-24 11:34:58
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_b
   start: 2020-01-24 11:34:58
   end: 2020-01-24 11:45:28
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_c
   start: 2020-01-24 11:45:28
   end: 2020-01-24 11:50:21
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_d
   start: 2020-01-24 11:50:21
   end: 2020-01-24 12:01:37
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_e
   start: 2020-01-24 12:02:44
   end: 2020-01-24 12:18:52
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_f
   start: 2020-01-24 12:17:45
   end: 2020-01-24 12:27:53
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_g
   start: 2020-01-24 12:28:15
   end: 2020-01-24 12:42:53
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_h
   start: 2020-01-24 12:47:24
   end: 2020-01-24 12:54:09
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_i
   start: 2020-01-24 12:56:46
   end: 2020-01-24 13:06:09
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_j
   start: 2020-01-24 13:06:09
   end: 2020-01-24 13:08:24
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_k
   start: 2020-01-24 13:08:47
   end: 2020-01-24 13:12:32
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_l
   start: 2020-01-24 13:17:47
   end: 2020-01-24 13:29:03
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_m
   start: 2020-01-24 13:32:03
   end: 2020-01-24 13:36:11
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_n
   start: 2020-01-24 13:36:33
   end: 2020-01-24 13:43:41
 - kinds:
+  - calibration
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_o
   start: 2020-01-24 13:44:03
   end: 2020-01-24 13:47:26
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_p
   start: 2020-01-24 13:47:49
   end: 2020-01-24 13:56:04
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0330_
+  segment_id: TO-0330_q
   start: 2020-01-24 13:59:27
   end: 2020-01-24 14:01:42

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
@@ -1,0 +1,132 @@
+name: RF02
+mission: EUREC4A
+platform: TO
+flight_id: TO-0331
+contacts: []
+date: 2020-01-24
+flight_report: ''
+takeoff: 2020-01-24 16:10:28
+landing: 2020-01-24 19:29:35
+events: []
+remarks: HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 16:25:28
+  end: 2020-01-24 16:45:37
+- kinds:
+  - profile
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 16:46:28
+  end: 2020-01-24 17:04:54
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:05:19
+  end: 2020-01-24 17:09:11
+- kinds:
+  - profile
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:11:19
+  end: 2020-01-24 17:14:19
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:15:11
+  end: 2020-01-24 17:21:11
+- kinds:
+  - profile
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:21:11
+  end: 2020-01-24 17:25:28
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:27:11
+  end: 2020-01-24 17:40:54
+- kinds:
+  - profile
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:42:36
+  end: 2020-01-24 17:46:02
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 17:46:54
+  end: 2020-01-24 17:59:45
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:06:36
+  end: 2020-01-24 18:17:45
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:20:19
+  end: 2020-01-24 18:25:02
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:26:45
+  end: 2020-01-24 18:28:53
+- kinds:
+  - profile
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:29:19
+  end: 2020-01-24 18:33:10
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:34:53
+  end: 2020-01-24 18:38:45
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:40:02
+  end: 2020-01-24 18:48:10
+- kinds:
+  - profile
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 18:55:53
+  end: 2020-01-24 19:10:27
+- kinds:
+  - level
+  name: ''
+  irregularities: ''
+  segment_id: ''
+  start: 2020-01-24 19:10:53
+  end: 2020-01-24 19:23:19

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
@@ -2,7 +2,10 @@ name: RF02
 mission: EUREC4A
 platform: TO
 flight_id: TO-0331
-contacts: []
+contacts:
+- name: Keith Bower
+  tags:
+  - flight PI
 date: 2020-01-24
 flight_report: ''
 takeoff: 2020-01-24 16:10:28
@@ -14,120 +17,131 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_tr1
   start: 2020-01-24 16:25:28
   end: 2020-01-24 16:45:37
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_prof1
   start: 2020-01-24 16:46:28
   end: 2020-01-24 17:04:54
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld1
   start: 2020-01-24 17:05:19
-  end: 2020-01-24 17:09:11
+  end: 2020-01-24 17:09:00
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_prof2
   start: 2020-01-24 17:11:19
   end: 2020-01-24 17:14:19
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld2
   start: 2020-01-24 17:15:11
   end: 2020-01-24 17:21:11
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_prof3
   start: 2020-01-24 17:21:11
   end: 2020-01-24 17:25:28
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld3
   start: 2020-01-24 17:27:11
   end: 2020-01-24 17:40:54
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_prof4
   start: 2020-01-24 17:42:36
   end: 2020-01-24 17:46:02
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld4
   start: 2020-01-24 17:46:54
   end: 2020-01-24 17:59:45
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld5
   start: 2020-01-24 18:06:36
   end: 2020-01-24 18:17:45
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 6'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld6
   start: 2020-01-24 18:20:19
   end: 2020-01-24 18:25:02
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 7'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld7
   start: 2020-01-24 18:26:45
   end: 2020-01-24 18:28:53
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_prof5
   start: 2020-01-24 18:29:19
   end: 2020-01-24 18:33:10
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 8'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld8
   start: 2020-01-24 18:34:53
   end: 2020-01-24 18:38:45
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 9'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_cld9
   start: 2020-01-24 18:40:02
   end: 2020-01-24 18:48:10
 - kinds:
   - profile
-  name: ''
+  name: 'profile 6'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_prof6
   start: 2020-01-24 18:55:53
   end: 2020-01-24 19:10:27
 - kinds:
   - level
-  name: ''
+  - bco_flyby
+  name: 'BCO flyby'
   irregularities: ''
-  segment_id: ''
+  segment_id: TO-0331_bco
   start: 2020-01-24 19:10:53
   end: 2020-01-24 19:23:19

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
@@ -19,14 +19,14 @@ segments:
   - level
   - transit
   name: 'transit to circle'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_tr1
   start: 2020-01-24 16:25:28
   end: 2020-01-24 16:45:37
 - kinds:
   - profile
   name: 'profile 1'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_prof1
   start: 2020-01-24 16:46:28
   end: 2020-01-24 17:04:54
@@ -34,14 +34,14 @@ segments:
   - level
   - cloud
   name: 'cloud 1'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld1
   start: 2020-01-24 17:05:19
   end: 2020-01-24 17:09:00
 - kinds:
   - profile
   name: 'profile 2'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_prof2
   start: 2020-01-24 17:11:19
   end: 2020-01-24 17:14:19
@@ -49,14 +49,14 @@ segments:
   - level
   - cloud
   name: 'cloud 2'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld2
   start: 2020-01-24 17:15:11
   end: 2020-01-24 17:21:11
 - kinds:
   - profile
   name: 'profile 3'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_prof3
   start: 2020-01-24 17:21:11
   end: 2020-01-24 17:25:28
@@ -64,14 +64,14 @@ segments:
   - level
   - cloud
   name: 'cloud 3'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld3
   start: 2020-01-24 17:27:11
   end: 2020-01-24 17:40:54
 - kinds:
   - profile
   name: 'profile 4'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_prof4
   start: 2020-01-24 17:42:36
   end: 2020-01-24 17:46:02
@@ -79,7 +79,7 @@ segments:
   - level
   - cloud
   name: 'cloud 4'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld4
   start: 2020-01-24 17:46:54
   end: 2020-01-24 17:59:45
@@ -87,7 +87,7 @@ segments:
   - level
   - cloud
   name: 'cloud 5'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld5
   start: 2020-01-24 18:06:36
   end: 2020-01-24 18:17:45
@@ -95,7 +95,7 @@ segments:
   - level
   - cloud
   name: 'cloud 6'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld6
   start: 2020-01-24 18:20:19
   end: 2020-01-24 18:25:02
@@ -103,14 +103,14 @@ segments:
   - level
   - cloud
   name: 'cloud 7'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld7
   start: 2020-01-24 18:26:45
   end: 2020-01-24 18:28:53
 - kinds:
   - profile
   name: 'profile 5'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_prof5
   start: 2020-01-24 18:29:19
   end: 2020-01-24 18:33:10
@@ -118,7 +118,7 @@ segments:
   - level
   - cloud
   name: 'cloud 8'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld8
   start: 2020-01-24 18:34:53
   end: 2020-01-24 18:38:45
@@ -126,14 +126,14 @@ segments:
   - level
   - cloud
   name: 'cloud 9'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_cld9
   start: 2020-01-24 18:40:02
   end: 2020-01-24 18:48:10
 - kinds:
   - profile
   name: 'profile 6'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_prof6
   start: 2020-01-24 18:55:53
   end: 2020-01-24 19:10:27
@@ -141,7 +141,7 @@ segments:
   - level
   - bco_flyby
   name: 'BCO flyby'
-  irregularities: ''
+  irregularities: []
   segment_id: TO-0331_bco
   start: 2020-01-24 19:10:53
   end: 2020-01-24 19:23:19

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200124b_0.1.yaml
@@ -8,7 +8,8 @@ flight_report: ''
 takeoff: 2020-01-24 16:10:28
 landing: 2020-01-24 19:29:35
 events: []
-remarks: HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
   or H2O_LICOR.
 segments:
 - kinds:

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126a_0.1.yaml
@@ -2,7 +2,10 @@ name: RF03
 mission: EUREC4A
 platform: TO
 flight_id: TO-0332
-contacts: []
+contacts:
+- name: Phil Rosenberg
+  tags:
+  - flight PI
 date: 2020-01-26
 flight_report: ''
 takeoff: 2020-01-26 11:44:55
@@ -14,92 +17,103 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_tr1
   start: 2020-01-26 12:01:17
   end: 2020-01-26 12:16:06
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_prof1
   start: 2020-01-26 12:16:06
   end: 2020-01-26 12:27:21
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a (no cloud)'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_bl1a_1
   start: 2020-01-26 12:27:51
   end: 2020-01-26 12:37:34
 - kinds:
   - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0332_
+  - boundary_layer
+  name: 'boundary layer 1a (shift to cloud)'
+  irregularities:
+  - Changed direction to be under clouds (next segment)
+  segment_id: TO-0332_bl1a_2
   start: 2020-01-26 12:39:06
   end: 2020-01-26 12:42:10
 - kinds:
   - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0332_
+  - boundary_layer
+  name: 'boundary layer 1a (cloud)'
+  irregularities:
+  - Changed direction to be under clouds from previous segment
+  segment_id: TO-0332_bl1a_3
   start: 2020-01-26 12:43:42
   end: 2020-01-26 12:54:26
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_bl1b
   start: 2020-01-26 13:01:35
   end: 2020-01-26 13:17:26
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2a'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_bl2a
   start: 2020-01-26 13:25:06
   end: 2020-01-26 13:36:51
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2b'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_bl2b
   start: 2020-01-26 13:39:24
   end: 2020-01-26 13:48:36
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_prof2
   start: 2020-01-26 13:48:36
   end: 2020-01-26 14:01:23
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_prof3
   start: 2020-01-26 14:02:24
   end: 2020-01-26 14:11:06
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_cb1
   start: 2020-01-26 14:11:06
   end: 2020-01-26 15:12:25
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_prof4
   start: 2020-01-26 15:11:24
   end: 2020-01-26 15:35:56
 - kinds:
   - level
-  name: ''
+  - bco_flyby
+  name: 'BCO flyby'
   irregularities: []
-  segment_id: TO-0332_
+  segment_id: TO-0332_bco
   start: 2020-01-26 15:16:31
   end: 2020-01-26 15:23:09

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126a_0.1.yaml
@@ -13,91 +13,91 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 12:01:17
   end: 2020-01-26 12:16:06
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 12:16:06
   end: 2020-01-26 12:27:21
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 12:27:51
   end: 2020-01-26 12:37:34
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 12:39:06
   end: 2020-01-26 12:42:10
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 12:43:42
   end: 2020-01-26 12:54:26
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 13:01:35
   end: 2020-01-26 13:17:26
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 13:25:06
   end: 2020-01-26 13:36:51
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 13:39:24
   end: 2020-01-26 13:48:36
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 13:48:36
   end: 2020-01-26 14:01:23
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 14:02:24
   end: 2020-01-26 14:11:06
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 14:11:06
   end: 2020-01-26 15:12:25
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0332_
   start: 2020-01-26 15:11:24
   end: 2020-01-26 15:35:56
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0332_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126a_0.1.yaml
@@ -1,0 +1,105 @@
+name: RF03
+mission: EUREC4A
+platform: TO
+flight_id: TO-0332
+contacts: []
+date: 2020-01-26
+flight_report: ''
+takeoff: 2020-01-26 11:44:55
+landing: 2020-01-26 15:37:55
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 12:01:17
+  end: 2020-01-26 12:16:06
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 12:16:06
+  end: 2020-01-26 12:27:21
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 12:27:51
+  end: 2020-01-26 12:37:34
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 12:39:06
+  end: 2020-01-26 12:42:10
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 12:43:42
+  end: 2020-01-26 12:54:26
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 13:01:35
+  end: 2020-01-26 13:17:26
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 13:25:06
+  end: 2020-01-26 13:36:51
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 13:39:24
+  end: 2020-01-26 13:48:36
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 13:48:36
+  end: 2020-01-26 14:01:23
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 14:02:24
+  end: 2020-01-26 14:11:06
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 14:11:06
+  end: 2020-01-26 15:12:25
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 15:11:24
+  end: 2020-01-26 15:35:56
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0332_
+  start: 2020-01-26 15:16:31
+  end: 2020-01-26 15:23:09

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
@@ -13,77 +13,77 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 17:56:50
   end: 2020-01-26 18:01:10
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 18:01:31
   end: 2020-01-26 18:12:42
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 18:13:25
   end: 2020-01-26 18:23:31
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 18:27:07
   end: 2020-01-26 18:36:29
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 18:37:56
   end: 2020-01-26 18:47:40
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 18:47:40
   end: 2020-01-26 19:06:03
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 19:05:41
   end: 2020-01-26 19:11:06
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 19:12:11
   end: 2020-01-26 19:18:40
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 19:23:21
   end: 2020-01-26 19:37:25
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_
   start: 2020-01-26 19:41:01
   end: 2020-01-26 20:02:39
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0333_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
@@ -56,7 +56,7 @@ segments:
   - boundary_layer
   name: 'boundary layer 2b'
   irregularities: []
-  segment_id: TO-0333_bl2a
+  segment_id: TO-0333_bl2b
   start: 2020-01-26 18:37:56
   end: 2020-01-26 18:47:40
 - kinds:

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
@@ -1,0 +1,91 @@
+name: RF04
+mission: EUREC4A
+platform: TO
+flight_id: TO-0333
+contacts: []
+date: 2020-01-26
+flight_report: ''
+takeoff: 2020-01-26 17:30:25
+landing: 2020-01-26 20:16:03
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 17:56:50
+  end: 2020-01-26 18:01:10
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 18:01:31
+  end: 2020-01-26 18:12:42
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 18:13:25
+  end: 2020-01-26 18:23:31
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 18:27:07
+  end: 2020-01-26 18:36:29
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 18:37:56
+  end: 2020-01-26 18:47:40
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 18:47:40
+  end: 2020-01-26 19:06:03
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 19:05:41
+  end: 2020-01-26 19:11:06
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 19:12:11
+  end: 2020-01-26 19:18:40
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 19:23:21
+  end: 2020-01-26 19:37:25
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 19:41:01
+  end: 2020-01-26 20:02:39
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0333_
+  start: 2020-01-26 20:04:05
+  end: 2020-01-26 20:08:03

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200126b_0.1.yaml
@@ -13,79 +13,95 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - profile
-  name: ''
+  - level
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0333_
-  start: 2020-01-26 17:56:50
+  segment_id: TO-0333_tr1
+  start: 2020-01-26 17:40:00
+  end: 2020-01-26 17:50:00
+- kinds:
+  - profile
+  name: 'profile 1'
+  irregularities: []
+  segment_id: TO-0333_prof1
+  start: 2020-01-26 17:50:00
   end: 2020-01-26 18:01:10
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_bl1a
   start: 2020-01-26 18:01:31
   end: 2020-01-26 18:12:42
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_bl1b
   start: 2020-01-26 18:13:25
   end: 2020-01-26 18:23:31
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2a'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_bl2a
   start: 2020-01-26 18:27:07
   end: 2020-01-26 18:36:29
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2b'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_bl2a
   start: 2020-01-26 18:37:56
   end: 2020-01-26 18:47:40
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_prof2
   start: 2020-01-26 18:47:40
   end: 2020-01-26 19:06:03
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_prof3
   start: 2020-01-26 19:05:41
   end: 2020-01-26 19:11:06
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_cld1
   start: 2020-01-26 19:12:11
   end: 2020-01-26 19:18:40
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_cld2
   start: 2020-01-26 19:23:21
   end: 2020-01-26 19:37:25
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_cld3
   start: 2020-01-26 19:41:01
   end: 2020-01-26 20:02:39
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0333_
+  segment_id: TO-0333_cld4
   start: 2020-01-26 20:04:05
   end: 2020-01-26 20:08:03

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128a_0.1.yaml
@@ -13,126 +13,126 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 13:42:54
   end: 2020-01-28 13:49:27
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 13:49:58
   end: 2020-01-28 13:59:02
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 14:00:32
   end: 2020-01-28 14:11:37
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 14:12:38
   end: 2020-01-28 14:23:12
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 14:23:12
   end: 2020-01-28 14:25:13
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 14:25:13
   end: 2020-01-28 14:54:57
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 14:53:56
   end: 2020-01-28 14:55:57
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 14:58:28
   end: 2020-01-28 15:22:39
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 15:23:39
   end: 2020-01-28 15:25:40
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 15:26:11
   end: 2020-01-28 15:55:24
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 15:56:54
   end: 2020-01-28 16:01:56
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 16:02:57
   end: 2020-01-28 16:06:59
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 16:09:00
   end: 2020-01-28 16:16:03
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 16:17:03
   end: 2020-01-28 16:32:10
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 16:32:10
   end: 2020-01-28 16:39:13
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 16:40:44
   end: 2020-01-28 16:43:45
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_
   start: 2020-01-28 16:44:46
   end: 2020-01-28 16:59:52
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0334_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128a_0.1.yaml
@@ -1,0 +1,140 @@
+name: RF05
+mission: EUREC4A
+platform: TO
+flight_id: TO-0334
+contacts: []
+date: 2020-01-28
+flight_report: ''
+takeoff: 2020-01-28 13:25:26
+landing: 2020-01-28 17:13:54
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 13:42:54
+  end: 2020-01-28 13:49:27
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 13:49:58
+  end: 2020-01-28 13:59:02
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 14:00:32
+  end: 2020-01-28 14:11:37
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 14:12:38
+  end: 2020-01-28 14:23:12
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 14:23:12
+  end: 2020-01-28 14:25:13
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 14:25:13
+  end: 2020-01-28 14:54:57
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 14:53:56
+  end: 2020-01-28 14:55:57
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 14:58:28
+  end: 2020-01-28 15:22:39
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 15:23:39
+  end: 2020-01-28 15:25:40
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 15:26:11
+  end: 2020-01-28 15:55:24
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 15:56:54
+  end: 2020-01-28 16:01:56
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 16:02:57
+  end: 2020-01-28 16:06:59
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 16:09:00
+  end: 2020-01-28 16:16:03
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 16:17:03
+  end: 2020-01-28 16:32:10
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 16:32:10
+  end: 2020-01-28 16:39:13
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 16:40:44
+  end: 2020-01-28 16:43:45
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 16:44:46
+  end: 2020-01-28 16:59:52
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0334_
+  start: 2020-01-28 17:04:55
+  end: 2020-01-28 17:11:28

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128a_0.1.yaml
@@ -14,127 +14,138 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_tr1
   start: 2020-01-28 13:42:54
   end: 2020-01-28 13:49:27
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_prof1
   start: 2020-01-28 13:49:58
   end: 2020-01-28 13:59:02
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_bl1a
   start: 2020-01-28 14:00:32
   end: 2020-01-28 14:11:37
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_bl1b
   start: 2020-01-28 14:12:38
   end: 2020-01-28 14:23:12
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_prof2
   start: 2020-01-28 14:23:12
   end: 2020-01-28 14:25:13
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_cb1
   start: 2020-01-28 14:25:13
   end: 2020-01-28 14:54:57
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_prof3
   start: 2020-01-28 14:53:56
   end: 2020-01-28 14:55:57
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_cld1
   start: 2020-01-28 14:58:28
   end: 2020-01-28 15:22:39
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_prof4
   start: 2020-01-28 15:23:39
   end: 2020-01-28 15:25:40
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_cld2
   start: 2020-01-28 15:26:11
   end: 2020-01-28 15:55:24
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_cld3
   start: 2020-01-28 15:56:54
   end: 2020-01-28 16:01:56
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_cld4
   start: 2020-01-28 16:02:57
   end: 2020-01-28 16:06:59
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_cld5
   start: 2020-01-28 16:09:00
   end: 2020-01-28 16:16:03
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 1'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_saw1
   start: 2020-01-28 16:17:03
   end: 2020-01-28 16:32:10
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_prof5
   start: 2020-01-28 16:32:10
   end: 2020-01-28 16:39:13
 - kinds:
   - profile
-  name: ''
+  name: 'profile 6'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_prof6
   start: 2020-01-28 16:40:44
   end: 2020-01-28 16:43:45
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_tr2
   start: 2020-01-28 16:44:46
   end: 2020-01-28 16:59:52
 - kinds:
   - level
-  name: ''
+  - bco_flyby
+  name: 'BCO flyby'
   irregularities: []
-  segment_id: TO-0334_
+  segment_id: TO-0334_bco
   start: 2020-01-28 17:04:55
   end: 2020-01-28 17:11:28

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
@@ -1,0 +1,133 @@
+name: RF06
+mission: EUREC4A
+platform: TO
+flight_id: TO-0335
+contacts: []
+date: 2020-01-28
+flight_report: ''
+takeoff: 2020-01-28 18:22:28
+landing: 2020-01-28 22:03:55
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 18:47:29
+  end: 2020-01-28 18:56:06
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 18:55:09
+  end: 2020-01-28 19:06:10
+- kinds:
+  - ''
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 18:55:38
+  end: 2020-01-28 18:56:35
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 19:04:44
+  end: 2020-01-28 19:10:29
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 19:10:58
+  end: 2020-01-28 19:21:02
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 19:22:28
+  end: 2020-01-28 19:27:44
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 19:29:11
+  end: 2020-01-28 19:31:34
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 19:33:01
+  end: 2020-01-28 20:20:57
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 20:22:52
+  end: 2020-01-28 20:24:47
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 20:26:13
+  end: 2020-01-28 20:32:27
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 20:34:50
+  end: 2020-01-28 20:37:14
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 20:39:38
+  end: 2020-01-28 20:44:54
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 20:46:21
+  end: 2020-01-28 20:54:01
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 20:55:27
+  end: 2020-01-28 21:09:50
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 21:13:11
+  end: 2020-01-28 21:28:03
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 21:29:29
+  end: 2020-01-28 21:44:20
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0335_
+  start: 2020-01-28 21:45:18
+  end: 2020-01-28 22:03:54

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
@@ -61,70 +61,70 @@ segments:
 - kinds:
   - level
   - cloud
-  name: 'cloud 3'
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0335_cld3
+  segment_id: TO-0335_cld4
   start: 2020-01-28 19:33:01
   end: 2020-01-28 20:20:57
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 1'
   irregularities: []
   segment_id: TO-0335_uncategorised1
   start: 2020-01-28 20:22:52
   end: 2020-01-28 20:24:47
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 2'
   irregularities: []
   segment_id: TO-0335_uncategorised2
   start: 2020-01-28 20:26:13
   end: 2020-01-28 20:32:27
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 3'
   irregularities: []
   segment_id: TO-0335_uncategorised3
   start: 2020-01-28 20:34:50
   end: 2020-01-28 20:37:14
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 4'
   irregularities: []
   segment_id: TO-0335_uncategorised4
   start: 2020-01-28 20:39:38
   end: 2020-01-28 20:44:54
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 5'
   irregularities: []
   segment_id: TO-0335_uncategorised5
   start: 2020-01-28 20:46:21
   end: 2020-01-28 20:54:01
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 6'
   irregularities: []
   segment_id: TO-0335_uncategorised6
   start: 2020-01-28 20:55:27
   end: 2020-01-28 21:09:50
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 7'
   irregularities: []
   segment_id: TO-0335_uncategorised7
   start: 2020-01-28 21:13:11
   end: 2020-01-28 21:28:03
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 8'
   irregularities: []
   segment_id: TO-0335_uncategorised8
   start: 2020-01-28 21:29:29
   end: 2020-01-28 21:44:20
 - kinds:
   - level
-  name: 'uncategorised'
+  name: 'uncategorised 9'
   irregularities: []
   segment_id: TO-0335_uncategorised9
   start: 2020-01-28 21:45:18

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
@@ -13,14 +13,14 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 18:47:29
   end: 2020-01-28 18:56:06
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
@@ -34,98 +34,98 @@ segments:
   start: 2020-01-28 18:55:38
   end: 2020-01-28 18:56:35
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 19:04:44
   end: 2020-01-28 19:10:29
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 19:10:58
   end: 2020-01-28 19:21:02
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 19:22:28
   end: 2020-01-28 19:27:44
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 19:29:11
   end: 2020-01-28 19:31:34
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 19:33:01
   end: 2020-01-28 20:20:57
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 20:22:52
   end: 2020-01-28 20:24:47
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 20:26:13
   end: 2020-01-28 20:32:27
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 20:34:50
   end: 2020-01-28 20:37:14
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 20:39:38
   end: 2020-01-28 20:44:54
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 20:46:21
   end: 2020-01-28 20:54:01
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 20:55:27
   end: 2020-01-28 21:09:50
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 21:13:11
   end: 2020-01-28 21:28:03
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_
   start: 2020-01-28 21:29:29
   end: 2020-01-28 21:44:20
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0335_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200128b_0.1.yaml
@@ -14,120 +14,118 @@ remarks:
 segments:
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_prof1
   start: 2020-01-28 18:47:29
   end: 2020-01-28 18:56:06
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_tr1
   start: 2020-01-28 18:55:09
   end: 2020-01-28 19:06:10
 - kinds:
-  - ''
-  name: ''
-  irregularities: []
-  segment_id: TO-0335_
-  start: 2020-01-28 18:55:38
-  end: 2020-01-28 18:56:35
-- kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_prof2
   start: 2020-01-28 19:04:44
   end: 2020-01-28 19:10:29
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_cld1
   start: 2020-01-28 19:10:58
   end: 2020-01-28 19:21:02
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_cld2
   start: 2020-01-28 19:22:28
   end: 2020-01-28 19:27:44
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_cld3
   start: 2020-01-28 19:29:11
   end: 2020-01-28 19:31:34
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_cld3
   start: 2020-01-28 19:33:01
   end: 2020-01-28 20:20:57
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised1
   start: 2020-01-28 20:22:52
   end: 2020-01-28 20:24:47
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised2
   start: 2020-01-28 20:26:13
   end: 2020-01-28 20:32:27
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised3
   start: 2020-01-28 20:34:50
   end: 2020-01-28 20:37:14
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised4
   start: 2020-01-28 20:39:38
   end: 2020-01-28 20:44:54
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised5
   start: 2020-01-28 20:46:21
   end: 2020-01-28 20:54:01
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised6
   start: 2020-01-28 20:55:27
   end: 2020-01-28 21:09:50
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised7
   start: 2020-01-28 21:13:11
   end: 2020-01-28 21:28:03
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised8
   start: 2020-01-28 21:29:29
   end: 2020-01-28 21:44:20
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0335_
+  segment_id: TO-0335_uncategorised9
   start: 2020-01-28 21:45:18
   end: 2020-01-28 22:03:54

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200130a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200130a_0.1.yaml
@@ -1,0 +1,105 @@
+name: RF07
+mission: EUREC4A
+platform: TO
+flight_id: TO-0336
+contacts: []
+date: 2020-01-30
+flight_report: ''
+takeoff: 2020-01-30 10:45:30
+landing: 2020-01-30 14:26:52
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 11:11:21
+  end: 2020-01-30 11:34:18
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 11:33:23
+  end: 2020-01-30 11:49:00
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 11:50:50
+  end: 2020-01-30 11:54:30
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 11:55:25
+  end: 2020-01-30 12:10:34
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 12:13:47
+  end: 2020-01-30 12:22:31
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 12:32:37
+  end: 2020-01-30 13:18:04
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:18:32
+  end: 2020-01-30 13:23:35
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:23:07
+  end: 2020-01-30 13:28:10
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:27:42
+  end: 2020-01-30 13:33:13
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:33:13
+  end: 2020-01-30 13:44:42
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:44:14
+  end: 2020-01-30 13:49:17
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:51:07
+  end: 2020-01-30 13:58:28
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0336_
+  start: 2020-01-30 13:59:23
+  end: 2020-01-30 14:09:02

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200130a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200130a_0.1.yaml
@@ -14,92 +14,115 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_tr1
   start: 2020-01-30 11:11:21
   end: 2020-01-30 11:34:18
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_prof1
   start: 2020-01-30 11:33:23
   end: 2020-01-30 11:49:00
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_bl1a
   start: 2020-01-30 11:50:50
   end: 2020-01-30 11:54:30
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_bl1b
   start: 2020-01-30 11:55:25
   end: 2020-01-30 12:10:34
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_prof2
   start: 2020-01-30 12:13:47
   end: 2020-01-30 12:22:31
 - kinds:
   - level
-  name: ''
+  name: 'uncategorised'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_uncategorised
+  start: 2020-01-30 12:22:31
+  end: 2020-01-30 12:30:00
+- kinds:
+  - level
+  - cloud
+  name: 'cloud 1'
+  irregularities: []
+  segment_id: TO-0336_cld1
   start: 2020-01-30 12:32:37
   end: 2020-01-30 13:18:04
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_prof3
   start: 2020-01-30 13:18:32
   end: 2020-01-30 13:23:35
 - kinds:
   - level
-  name: ''
+  - above_cloud
+  name: 'above cloud 1'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_ac1
   start: 2020-01-30 13:23:07
   end: 2020-01-30 13:28:10
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_prof4
   start: 2020-01-30 13:27:42
   end: 2020-01-30 13:33:13
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_cld2
   start: 2020-01-30 13:33:13
   end: 2020-01-30 13:44:42
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_prof5
   start: 2020-01-30 13:44:14
   end: 2020-01-30 13:49:17
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_cld3
   start: 2020-01-30 13:51:07
   end: 2020-01-30 13:58:28
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2'
   irregularities: []
-  segment_id: TO-0336_
+  segment_id: TO-0336_bl2
   start: 2020-01-30 13:59:23
   end: 2020-01-30 14:09:02
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0336_bco
+  start: 2020-01-30 14:25:00
+  end: 2020-01-30 14:27:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200130a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200130a_0.1.yaml
@@ -13,91 +13,91 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 11:11:21
   end: 2020-01-30 11:34:18
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 11:33:23
   end: 2020-01-30 11:49:00
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 11:50:50
   end: 2020-01-30 11:54:30
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 11:55:25
   end: 2020-01-30 12:10:34
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 12:13:47
   end: 2020-01-30 12:22:31
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 12:32:37
   end: 2020-01-30 13:18:04
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 13:18:32
   end: 2020-01-30 13:23:35
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 13:23:07
   end: 2020-01-30 13:28:10
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 13:27:42
   end: 2020-01-30 13:33:13
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 13:33:13
   end: 2020-01-30 13:44:42
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 13:44:14
   end: 2020-01-30 13:49:17
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_
   start: 2020-01-30 13:51:07
   end: 2020-01-30 13:58:28
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0336_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131a_0.1.yaml
@@ -13,112 +13,112 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 13:43:38
   end: 2020-01-31 13:57:07
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 14:00:43
   end: 2020-01-31 14:07:00
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 14:07:00
   end: 2020-01-31 14:20:30
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 14:21:51
   end: 2020-01-31 14:31:44
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 14:33:32
   end: 2020-01-31 14:51:04
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 14:53:46
   end: 2020-01-31 14:57:49
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 14:58:43
   end: 2020-01-31 15:03:13
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 15:03:13
   end: 2020-01-31 15:13:33
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 15:13:06
   end: 2020-01-31 15:25:42
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 15:31:05
   end: 2020-01-31 15:38:44
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 15:39:38
   end: 2020-01-31 15:50:25
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 15:53:34
   end: 2020-01-31 15:57:10
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 15:57:37
   end: 2020-01-31 16:01:13
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 16:03:28
   end: 2020-01-31 16:09:18
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0337_
   start: 2020-01-31 16:21:54
   end: 2020-01-31 16:33:35
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0337_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131a_0.1.yaml
@@ -1,0 +1,126 @@
+name: RF08
+mission: EUREC4A
+platform: TO
+flight_id: TO-0337
+contacts: []
+date: 2020-01-31
+flight_report: ''
+takeoff: 2020-01-31 13:19:59
+landing: 2020-01-31 16:55:07
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 13:43:38
+  end: 2020-01-31 13:57:07
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 14:00:43
+  end: 2020-01-31 14:07:00
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 14:07:00
+  end: 2020-01-31 14:20:30
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 14:21:51
+  end: 2020-01-31 14:31:44
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 14:33:32
+  end: 2020-01-31 14:51:04
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 14:53:46
+  end: 2020-01-31 14:57:49
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 14:58:43
+  end: 2020-01-31 15:03:13
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 15:03:13
+  end: 2020-01-31 15:13:33
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 15:13:06
+  end: 2020-01-31 15:25:42
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 15:31:05
+  end: 2020-01-31 15:38:44
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 15:39:38
+  end: 2020-01-31 15:50:25
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 15:53:34
+  end: 2020-01-31 15:57:10
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 15:57:37
+  end: 2020-01-31 16:01:13
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 16:03:28
+  end: 2020-01-31 16:09:18
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 16:21:54
+  end: 2020-01-31 16:33:35
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0337_
+  start: 2020-01-31 16:34:02
+  end: 2020-01-31 16:38:05

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131a_0.1.yaml
@@ -14,113 +14,138 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_tr1
   start: 2020-01-31 13:43:38
   end: 2020-01-31 13:57:07
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_prof1
   start: 2020-01-31 14:00:43
   end: 2020-01-31 14:07:00
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_bl1a
   start: 2020-01-31 14:07:00
   end: 2020-01-31 14:20:30
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_bl1b
   start: 2020-01-31 14:21:51
   end: 2020-01-31 14:31:44
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_cb1
   start: 2020-01-31 14:33:32
   end: 2020-01-31 14:51:04
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_cld1
   start: 2020-01-31 14:53:46
   end: 2020-01-31 14:57:49
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_cld2
   start: 2020-01-31 14:58:43
   end: 2020-01-31 15:03:13
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_prof2
   start: 2020-01-31 15:03:13
   end: 2020-01-31 15:13:33
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_cld3
   start: 2020-01-31 15:13:06
   end: 2020-01-31 15:25:42
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 1'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_saw1
   start: 2020-01-31 15:31:05
   end: 2020-01-31 15:38:44
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 2'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_saw2
   start: 2020-01-31 15:39:38
   end: 2020-01-31 15:50:25
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_prof3
   start: 2020-01-31 15:53:34
   end: 2020-01-31 15:57:10
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_prof4
   start: 2020-01-31 15:57:37
   end: 2020-01-31 16:01:13
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_cld4
   start: 2020-01-31 16:03:28
   end: 2020-01-31 16:09:18
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_cld5
+  start: 2020-01-31 16:10:00
+  end: 2020-01-31 16:16:00
+- kinds:
+  - level
+  - transit
+  name: 'transit from circle'
+  irregularities: []
+  segment_id: TO-0337_tr2
   start: 2020-01-31 16:21:54
   end: 2020-01-31 16:33:35
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0337_
+  segment_id: TO-0337_prof5
   start: 2020-01-31 16:34:02
   end: 2020-01-31 16:38:05
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0337_bco
+  start: 2020-01-31 16:20:00
+  end: 2020-01-31 16:22:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131b_0.1.yaml
@@ -13,105 +13,105 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 18:48:45
   end: 2020-01-31 19:02:49
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 19:16:53
   end: 2020-01-31 19:32:30
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 19:38:14
   end: 2020-01-31 19:52:18
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 19:52:49
   end: 2020-01-31 20:13:39
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 20:13:39
   end: 2020-01-31 20:22:31
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 20:16:47
   end: 2020-01-31 20:28:14
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 20:32:56
   end: 2020-01-31 20:40:44
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 20:40:44
   end: 2020-01-31 21:04:11
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 21:12:00
   end: 2020-01-31 21:19:49
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 21:20:20
   end: 2020-01-31 21:27:06
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 21:30:14
   end: 2020-01-31 21:46:54
 - kinds:
-  - Sawtooth
+  - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 21:45:20
   end: 2020-01-31 22:06:41
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 22:07:13
   end: 2020-01-31 22:10:20
 - kinds:
-  - Transit
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0338_
   start: 2020-01-31 22:09:49
   end: 2020-01-31 22:21:17
 - kinds:
-  - Profile
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0338_

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200131b_0.1.yaml
@@ -1,0 +1,119 @@
+name: RF09
+mission: EUREC4A
+platform: TO
+flight_id: TO-0338
+contacts: []
+date: 2020-01-31
+flight_report: ''
+takeoff: 2020-01-31 18:24:57
+landing: 2020-01-31 22:30:56
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 18:48:45
+  end: 2020-01-31 19:02:49
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 19:16:53
+  end: 2020-01-31 19:32:30
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 19:38:14
+  end: 2020-01-31 19:52:18
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 19:52:49
+  end: 2020-01-31 20:13:39
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 20:13:39
+  end: 2020-01-31 20:22:31
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 20:16:47
+  end: 2020-01-31 20:28:14
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 20:32:56
+  end: 2020-01-31 20:40:44
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 20:40:44
+  end: 2020-01-31 21:04:11
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 21:12:00
+  end: 2020-01-31 21:19:49
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 21:20:20
+  end: 2020-01-31 21:27:06
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 21:30:14
+  end: 2020-01-31 21:46:54
+- kinds:
+  - Sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 21:45:20
+  end: 2020-01-31 22:06:41
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 22:07:13
+  end: 2020-01-31 22:10:20
+- kinds:
+  - Transit
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 22:09:49
+  end: 2020-01-31 22:21:17
+- kinds:
+  - Profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0338_
+  start: 2020-01-31 22:21:17
+  end: 2020-01-31 22:24:55

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200202a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200202a_0.1.yaml
@@ -1,0 +1,182 @@
+name: RF10
+mission: EUREC4A
+platform: TO
+flight_id: TO-0339
+contacts: []
+date: 2020-02-02
+flight_report: ''
+takeoff: 2020-02-02 11:50:42
+landing: 2020-02-02 15:31:57
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:00:20
+  end: 2020-02-02 12:00:20

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200202a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200202a_0.1.yaml
@@ -17,166 +17,124 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
+  start: 2020-02-02 12:06:44
+  end: 2020-02-02 12:17:29
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 12:18:23
+  end: 2020-02-02 12:28:41
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
+  start: 2020-02-02 12:30:29
+  end: 2020-02-02 12:45:43
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
+  start: 2020-02-02 12:45:16
+  end: 2020-02-02 13:00:30
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
+  start: 2020-02-02 13:01:24
+  end: 2020-02-02 13:01:24
 - kinds:
   - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0339_
-  start: 2020-02-02 12:00:20
-  end: 2020-02-02 12:00:20
+  start: 2020-02-02 13:01:24
+  end: 2020-02-02 13:14:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 13:14:50
+  end: 2020-02-02 13:19:46
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 13:22:54
+  end: 2020-02-02 13:39:29
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 13:43:58
+  end: 2020-02-02 13:50:41
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 13:53:22
+  end: 2020-02-02 13:57:24
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 14:02:20
+  end: 2020-02-02 14:05:28
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 14:12:11
+  end: 2020-02-02 14:18:55
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 14:18:55
+  end: 2020-02-02 14:32:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 14:32:48
+  end: 2020-02-02 14:36:50
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 14:38:37
+  end: 2020-02-02 14:50:43
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 14:53:51
+  end: 2020-02-02 15:06:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 15:07:18
+  end: 2020-02-02 15:16:16
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0339_
+  start: 2020-02-02 15:18:30
+  end: 2020-02-02 15:27:28

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200202a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200202a_0.1.yaml
@@ -14,127 +14,139 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_tr1
   start: 2020-02-02 12:06:44
   end: 2020-02-02 12:17:29
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_prof1
   start: 2020-02-02 12:18:23
   end: 2020-02-02 12:28:41
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_bl1
   start: 2020-02-02 12:30:29
   end: 2020-02-02 12:45:43
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_prof2
   start: 2020-02-02 12:45:16
   end: 2020-02-02 13:00:30
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0339_
-  start: 2020-02-02 13:01:24
-  end: 2020-02-02 13:01:24
-- kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 1'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_saw1
   start: 2020-02-02 13:01:24
   end: 2020-02-02 13:14:23
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld1
   start: 2020-02-02 13:14:50
   end: 2020-02-02 13:19:46
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld2
   start: 2020-02-02 13:22:54
   end: 2020-02-02 13:39:29
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld3
   start: 2020-02-02 13:43:58
   end: 2020-02-02 13:50:41
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld4
   start: 2020-02-02 13:53:22
   end: 2020-02-02 13:57:24
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld5
   start: 2020-02-02 14:02:20
   end: 2020-02-02 14:05:28
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 6'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld6
   start: 2020-02-02 14:12:11
   end: 2020-02-02 14:18:55
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_prof3
   start: 2020-02-02 14:18:55
   end: 2020-02-02 14:32:21
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cb1
   start: 2020-02-02 14:32:48
   end: 2020-02-02 14:36:50
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 7'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_cld7
   start: 2020-02-02 14:38:37
   end: 2020-02-02 14:50:43
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_tr2
   start: 2020-02-02 14:53:51
   end: 2020-02-02 15:06:51
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_prof4
   start: 2020-02-02 15:07:18
   end: 2020-02-02 15:16:16
 - kinds:
-  - profile
-  name: ''
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
   irregularities: []
-  segment_id: TO-0339_
+  segment_id: TO-0339_bco
+  start: 2020-02-02 15:16:26
+  end: 2020-02-02 15:18:30
+- kinds:
+  - profile
+  name: 'profile 5'
+  irregularities: []
+  segment_id: TO-0339_prof5
   start: 2020-02-02 15:18:30
   end: 2020-02-02 15:27:28

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
@@ -14,127 +14,146 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_tr1
   start: 2020-02-05 11:46:24
   end: 2020-02-05 12:06:51
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_prof1
   start: 2020-02-05 12:06:24
   end: 2020-02-05 12:12:11
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_saw1
   start: 2020-02-05 12:06:24
   end: 2020-02-05 12:29:30
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_prof2
   start: 2020-02-05 12:14:51
   end: 2020-02-05 12:22:24
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_cld1
   start: 2020-02-05 12:29:57
   end: 2020-02-05 12:42:50
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_cld2
   start: 2020-02-05 12:44:10
   end: 2020-02-05 13:01:30
 - kinds:
   - level
-  name: ''
+  - above_cloud
+  name: 'above cloud 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_ac1
   start: 2020-02-05 13:04:10
   end: 2020-02-05 13:08:36
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth2'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_saw2
   start: 2020-02-05 13:08:10
   end: 2020-02-05 13:28:10
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_cld3
   start: 2020-02-05 13:28:10
   end: 2020-02-05 13:40:09
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_prof3
   start: 2020-02-05 13:41:03
   end: 2020-02-05 13:54:23
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_bl1
   start: 2020-02-05 13:57:56
   end: 2020-02-05 14:01:29
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_cb1
   start: 2020-02-05 14:02:22
   end: 2020-02-05 14:12:09
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_bl1
   start: 2020-02-05 14:14:49
   end: 2020-02-05 14:26:49
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_prof4
   start: 2020-02-05 14:26:49
   end: 2020-02-05 14:30:22
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_cld4
   start: 2020-02-05 14:30:49
   end: 2020-02-05 14:40:09
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_cld5
   start: 2020-02-05 14:42:48
   end: 2020-02-05 14:52:08
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_tr2
   start: 2020-02-05 14:53:55
   end: 2020-02-05 14:57:28
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0340_
+  segment_id: TO-0340_prof5
   start: 2020-02-05 14:57:28
   end: 2020-02-05 15:04:35
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0340_bco
+  start: 2020-02-05 15:04:35
+  end: 2020-02-05 15:06:35

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
@@ -17,131 +17,124 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 11:46:24
+  end: 2020-02-05 12:06:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 12:06:24
+  end: 2020-02-05 12:12:11
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 12:06:24
+  end: 2020-02-05 12:29:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 12:14:51
+  end: 2020-02-05 12:22:24
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 12:29:57
+  end: 2020-02-05 12:42:50
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 12:44:10
+  end: 2020-02-05 13:01:30
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 13:04:10
+  end: 2020-02-05 13:08:36
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 13:08:10
+  end: 2020-02-05 13:28:10
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 13:28:10
+  end: 2020-02-05 13:40:09
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 13:41:03
+  end: 2020-02-05 13:54:23
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 13:57:56
+  end: 2020-02-05 14:01:29
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 14:02:22
+  end: 2020-02-05 14:12:09
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 14:14:49
+  end: 2020-02-05 14:26:49
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 14:26:49
+  end: 2020-02-05 14:30:22
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 14:30:49
+  end: 2020-02-05 14:40:09
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 14:42:48
+  end: 2020-02-05 14:52:08
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 14:53:55
+  end: 2020-02-05 14:57:28
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0340_
-  start: 2020-02-05 11:40:30
-  end: 2020-02-05 11:40:30
+  start: 2020-02-05 14:57:28
+  end: 2020-02-05 15:04:35

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
@@ -106,9 +106,9 @@ segments:
 - kinds:
   - level
   - boundary_layer
-  name: 'boundary layer 1'
+  name: 'boundary layer 2'
   irregularities: []
-  segment_id: TO-0340_bl1
+  segment_id: TO-0340_bl2
   start: 2020-02-05 14:14:49
   end: 2020-02-05 14:26:49
 - kinds:

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205a_0.1.yaml
@@ -1,0 +1,147 @@
+name: RF11
+mission: EUREC4A
+platform: TO
+flight_id: TO-0340
+contacts: []
+date: 2020-02-05
+flight_report: ''
+takeoff: 2020-02-05 11:23:54
+landing: 2020-02-05 15:10:23
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0340_
+  start: 2020-02-05 11:40:30
+  end: 2020-02-05 11:40:30

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205b_0.1.yaml
@@ -14,127 +14,148 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  - cloud
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_tr1
   start: 2020-02-05 16:32:32
   end: 2020-02-05 16:45:45
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_prof1
   start: 2020-02-05 16:48:56
   end: 2020-02-05 16:55:19
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld1
   start: 2020-02-05 16:54:51
   end: 2020-02-05 17:13:04
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld2
   start: 2020-02-05 17:13:32
   end: 2020-02-05 17:39:02
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cb1
   start: 2020-02-05 17:39:29
   end: 2020-02-05 17:58:37
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld3
   start: 2020-02-05 18:01:21
   end: 2020-02-05 18:10:00
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld4
   start: 2020-02-05 18:11:49
   end: 2020-02-05 18:19:34
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_prof2
   start: 2020-02-05 18:19:07
   end: 2020-02-05 18:26:51
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld5
   start: 2020-02-05 18:21:51
   end: 2020-02-05 18:24:34
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 6'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld6
   start: 2020-02-05 18:26:24
   end: 2020-02-05 18:34:36
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 7'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld7
   start: 2020-02-05 18:36:52
   end: 2020-02-05 18:49:10
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_prof3
   start: 2020-02-05 18:48:15
   end: 2020-02-05 18:59:11
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 8'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_cld8
   start: 2020-02-05 18:51:27
   end: 2020-02-05 18:54:11
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_prof4
   start: 2020-02-05 18:59:39
   end: 2020-02-05 19:17:52
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_bl1
   start: 2020-02-05 19:19:41
   end: 2020-02-05 19:30:37
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_prof5
   start: 2020-02-05 19:30:37
   end: 2020-02-05 19:37:54
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_tr2
   start: 2020-02-05 19:36:59
   end: 2020-02-05 19:44:44
 - kinds:
   - profile
-  name: ''
+  name: 'profile 6'
   irregularities: []
-  segment_id: TO-0341_
+  segment_id: TO-0341_prof6
   start: 2020-02-05 19:44:44
   end: 2020-02-05 19:53:50
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0341_bco
+  start: 2020-02-05 19:53:50
+  end: 2020-02-05 19:55:50

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205b_0.1.yaml
@@ -17,131 +17,124 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 16:32:32
+  end: 2020-02-05 16:45:45
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 16:48:56
+  end: 2020-02-05 16:55:19
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:54:51
+  end: 2020-02-05 17:13:04
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 17:13:32
+  end: 2020-02-05 17:39:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 17:39:29
+  end: 2020-02-05 17:58:37
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 18:01:21
+  end: 2020-02-05 18:10:00
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 18:11:49
+  end: 2020-02-05 18:19:34
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 18:19:07
+  end: 2020-02-05 18:26:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 18:21:51
+  end: 2020-02-05 18:24:34
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 18:26:24
+  end: 2020-02-05 18:34:36
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 18:36:52
+  end: 2020-02-05 18:49:10
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 18:48:15
+  end: 2020-02-05 18:59:11
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 18:51:27
+  end: 2020-02-05 18:54:11
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 18:59:39
+  end: 2020-02-05 19:17:52
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 19:19:41
+  end: 2020-02-05 19:30:37
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 19:30:37
+  end: 2020-02-05 19:37:54
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 19:36:59
+  end: 2020-02-05 19:44:44
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0341_
-  start: 2020-02-05 16:26:02
-  end: 2020-02-05 16:26:02
+  start: 2020-02-05 19:44:44
+  end: 2020-02-05 19:53:50

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200205b_0.1.yaml
@@ -1,0 +1,147 @@
+name: RF12
+mission: EUREC4A
+platform: TO
+flight_id: TO-0341
+contacts: []
+date: 2020-02-05
+flight_report: ''
+takeoff: 2020-02-05 16:17:52
+landing: 2020-02-05 20:01:09
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0341_
+  start: 2020-02-05 16:26:02
+  end: 2020-02-05 16:26:02

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200206a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200206a_0.1.yaml
@@ -17,47 +17,82 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
-- kinds:
-  - calibration
-  name: ''
-  irregularities: []
-  segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
+  start: 2020-02-06 14:22:39
+  end: 2020-02-06 14:47:44
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
+  start: 2020-02-06 14:46:49
+  end: 2020-02-06 14:50:01
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:50:01
+  end: 2020-02-06 15:00:58
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 15:03:15
+  end: 2020-02-06 15:48:52
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0342_
-  start: 2020-02-06 14:16:35
-  end: 2020-02-06 14:16:35
+  start: 2020-02-06 15:48:24
+  end: 2020-02-06 15:52:03
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 15:51:36
+  end: 2020-02-06 16:40:52
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 16:41:19
+  end: 2020-02-06 16:48:37
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 16:49:04
+  end: 2020-02-06 16:56:22
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 16:55:55
+  end: 2020-02-06 17:04:08
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 17:04:08
+  end: 2020-02-06 17:10:03
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 17:11:53
+  end: 2020-02-06 17:26:01
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 17:26:29
+  end: 2020-02-06 17:42:27

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200206a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200206a_0.1.yaml
@@ -1,0 +1,63 @@
+name: RF13
+mission: EUREC4A
+platform: TO
+flight_id: TO-0342
+contacts: []
+date: 2020-02-06
+flight_report: ''
+takeoff: 2020-02-06 13:51:21
+landing: 2020-02-06 17:52:02
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35
+- kinds:
+  - calibration
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0342_
+  start: 2020-02-06 14:16:35
+  end: 2020-02-06 14:16:35

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200206a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200206a_0.1.yaml
@@ -9,90 +9,86 @@ takeoff: 2020-02-06 13:51:21
 landing: 2020-02-06 17:52:02
 events: []
 remarks:
+- Calibration flight
+- Science legs near end of flight
 - HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
   or H2O_LICOR.
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_tr1
   start: 2020-02-06 14:22:39
   end: 2020-02-06 14:47:44
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0342_
-  start: 2020-02-06 14:46:49
-  end: 2020-02-06 14:50:01
-- kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_a
   start: 2020-02-06 14:50:01
   end: 2020-02-06 15:00:58
 - kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_b
   start: 2020-02-06 15:03:15
   end: 2020-02-06 15:48:52
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0342_
-  start: 2020-02-06 15:48:24
-  end: 2020-02-06 15:52:03
-- kinds:
+  - calibration
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_c
   start: 2020-02-06 15:51:36
   end: 2020-02-06 16:40:52
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_prof1
   start: 2020-02-06 16:41:19
   end: 2020-02-06 16:48:37
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_cld1
   start: 2020-02-06 16:49:04
   end: 2020-02-06 16:56:22
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_prof2
   start: 2020-02-06 16:55:55
   end: 2020-02-06 17:04:08
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_bl1
   start: 2020-02-06 17:04:08
   end: 2020-02-06 17:10:03
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary_layer 2'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_bl2
   start: 2020-02-06 17:11:53
   end: 2020-02-06 17:26:01
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0342_
+  segment_id: TO-0342_tr2
   start: 2020-02-06 17:26:29
   end: 2020-02-06 17:42:27

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207a_0.1.yaml
@@ -14,113 +14,133 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  - cloud
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_tr1
   start: 2020-02-07 12:14:46
   end: 2020-02-07 12:32:52
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_prof1
   start: 2020-02-07 12:31:30
   end: 2020-02-07 12:42:22
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 1'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp1
   start: 2020-02-07 12:42:22
   end: 2020-02-07 13:05:26
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 2'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp2
   start: 2020-02-07 13:09:03
   end: 2020-02-07 13:21:15
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 3'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp3
   start: 2020-02-07 13:23:31
   end: 2020-02-07 13:33:55
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 4'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp4
   start: 2020-02-07 13:36:11
   end: 2020-02-07 13:57:26
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 5'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp5
   start: 2020-02-07 14:04:13
   end: 2020-02-07 14:11:28
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 6'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp6
   start: 2020-02-07 14:15:32
   end: 2020-02-07 14:26:50
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_prof2
   start: 2020-02-07 14:27:45
   end: 2020-02-07 14:34:32
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 7'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cp7
   start: 2020-02-07 14:34:59
   end: 2020-02-07 14:41:19
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cld1
   start: 2020-02-07 14:45:50
   end: 2020-02-07 14:48:33
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cb1
   start: 2020-02-07 14:56:41
   end: 2020-02-07 15:02:07
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_prof3
   start: 2020-02-07 15:03:28
   end: 2020-02-07 15:16:35
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_prof4
   start: 2020-02-07 15:17:57
   end: 2020-02-07 15:22:55
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_cld2
   start: 2020-02-07 15:23:22
   end: 2020-02-07 15:27:54
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0343_
+  segment_id: TO-0343_prof5
   start: 2020-02-07 15:27:54
   end: 2020-02-07 15:37:24
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0343_bco
+  start: 2020-02-07 15:38:00
+  end: 2020-02-07 15:40:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207a_0.1.yaml
@@ -17,103 +17,110 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
+  start: 2020-02-07 12:14:46
+  end: 2020-02-07 12:32:52
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
+  start: 2020-02-07 12:31:30
+  end: 2020-02-07 12:42:22
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:42:22
+  end: 2020-02-07 13:05:26
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 13:09:03
+  end: 2020-02-07 13:21:15
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 13:23:31
+  end: 2020-02-07 13:33:55
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 13:36:11
+  end: 2020-02-07 13:57:26
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 14:04:13
+  end: 2020-02-07 14:11:28
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 14:15:32
+  end: 2020-02-07 14:26:50
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
+  start: 2020-02-07 14:27:45
+  end: 2020-02-07 14:34:32
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 14:34:59
+  end: 2020-02-07 14:41:19
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 14:45:50
+  end: 2020-02-07 14:48:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 14:56:41
+  end: 2020-02-07 15:02:07
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
+  start: 2020-02-07 15:03:28
+  end: 2020-02-07 15:16:35
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0343_
-  start: 2020-02-07 12:09:40
-  end: 2020-02-07 12:09:40
+  start: 2020-02-07 15:17:57
+  end: 2020-02-07 15:22:55
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 15:23:22
+  end: 2020-02-07 15:27:54
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 15:27:54
+  end: 2020-02-07 15:37:24

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207a_0.1.yaml
@@ -1,0 +1,119 @@
+name: RF14
+mission: EUREC4A
+platform: TO
+flight_id: TO-0343
+contacts: []
+date: 2020-02-07
+flight_report: ''
+takeoff: 2020-02-07 11:49:13
+landing: 2020-02-07 15:43:18
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0343_
+  start: 2020-02-07 12:09:40
+  end: 2020-02-07 12:09:40

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
@@ -17,124 +17,117 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
+  start: 2020-02-07 17:16:04
+  end: 2020-02-07 17:29:27
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
+  start: 2020-02-07 17:32:02
+  end: 2020-02-07 17:43:42
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:44:33
+  end: 2020-02-07 18:05:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 18:07:26
+  end: 2020-02-07 18:10:01
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
+  start: 2020-02-07 18:11:45
+  end: 2020-02-07 18:26:00
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 18:28:35
+  end: 2020-02-07 18:31:10
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 18:32:28
+  end: 2020-02-07 18:38:57
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 18:40:14
+  end: 2020-02-07 18:44:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 18:48:00
+  end: 2020-02-07 18:53:11
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
+  start: 2020-02-07 18:53:11
+  end: 2020-02-07 19:00:06
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 19:00:32
+  end: 2020-02-07 19:10:53
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 19:12:37
+  end: 2020-02-07 19:19:05
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 19:19:57
+  end: 2020-02-07 19:26:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 19:28:35
+  end: 2020-02-07 19:35:55
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
+  start: 2020-02-07 19:36:21
+  end: 2020-02-07 19:40:14
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 19:40:40
+  end: 2020-02-07 19:50:10
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 17:10:20
-  end: 2020-02-07 17:10:20
+  start: 2020-02-07 19:50:10
+  end: 2020-02-07 20:10:01

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
@@ -1,0 +1,140 @@
+name: RF15
+mission: EUREC4A
+platform: TO
+flight_id: TO-0344
+contacts: []
+date: 2020-02-07
+flight_report: ''
+takeoff: 2020-02-07 17:03:22
+landing: 2020-02-07 20:34:13
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0344_
+  start: 2020-02-07 17:10:20
+  end: 2020-02-07 17:10:20

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
@@ -151,7 +151,7 @@ segments:
 - kinds:
   - level
   - transit
-  name: 'transit back to Barbados'
+  name: 'transit from circle'
   irregularities: []
   segment_id: TO-0344_tr2
   start: 2020-02-07 20:11:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200207b_0.1.yaml
@@ -2,7 +2,11 @@ name: RF15
 mission: EUREC4A
 platform: TO
 flight_id: TO-0344
-contacts: []
+contacts:
+- name: Leo Saffin
+  email: l.saffin@leeds.ac.uk
+  tags:
+    - flight PI
 date: 2020-02-07
 flight_report: ''
 takeoff: 2020-02-07 17:03:22
@@ -14,120 +18,141 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_tr1
   start: 2020-02-07 17:16:04
   end: 2020-02-07 17:29:27
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_prof1
   start: 2020-02-07 17:32:02
   end: 2020-02-07 17:43:42
 - kinds:
   - level
-  name: ''
+  - boundary layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_bl1
   start: 2020-02-07 17:44:33
   end: 2020-02-07 18:05:17
 - kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0344_
-  start: 2020-02-07 18:07:26
-  end: 2020-02-07 18:10:01
-- kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_prof2
   start: 2020-02-07 18:11:45
   end: 2020-02-07 18:26:00
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cold pool cloud arc 1'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cld_arc1
   start: 2020-02-07 18:28:35
   end: 2020-02-07 18:31:10
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cold pool cloud arc 2'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cld_arc2
   start: 2020-02-07 18:32:28
   end: 2020-02-07 18:38:57
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cold pool cloud arc 3'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cld_arc3
   start: 2020-02-07 18:40:14
   end: 2020-02-07 18:44:33
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cold pool cloud arc 4'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cld_arc4
   start: 2020-02-07 18:48:00
   end: 2020-02-07 18:53:11
 - kinds:
   - profile
-  name: ''
+  name: 'profile inside cold pool'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_prof_cp
   start: 2020-02-07 18:53:11
   end: 2020-02-07 19:00:06
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 1'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cp1
   start: 2020-02-07 19:00:32
+  end: 2020-02-07 19:05:00
+- kinds:
+  - level
+  - cold_pool
+  name: 'cold pool 2'
+  irregularities: []
+  segment_id: TO-0344_cp2
+  start: 2020-02-07 19:05:30
   end: 2020-02-07 19:10:53
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 3'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cp3
   start: 2020-02-07 19:12:37
   end: 2020-02-07 19:19:05
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 4'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cp4
   start: 2020-02-07 19:19:57
   end: 2020-02-07 19:26:51
 - kinds:
   - level
-  name: ''
+  - cold_pool
+  name: 'cold pool 5'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cp5
   start: 2020-02-07 19:28:35
   end: 2020-02-07 19:35:55
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_prof3
   start: 2020-02-07 19:36:21
   end: 2020-02-07 19:40:14
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_cld1
   start: 2020-02-07 19:40:40
   end: 2020-02-07 19:50:10
 - kinds:
   - profile
-  name: ''
+  - cloud
+  name: 'profile of an individual developing cloud'
   irregularities: []
-  segment_id: TO-0344_
+  segment_id: TO-0344_prof_cld
   start: 2020-02-07 19:50:10
   end: 2020-02-07 20:10:01
+- kinds:
+  - level
+  - transit
+  name: 'transit back to Barbados'
+  irregularities: []
+  segment_id: TO-0344_tr2
+  start: 2020-02-07 20:11:00
+  end: 2020-02-07 20:32:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209a_0.1.yaml
@@ -1,0 +1,105 @@
+name: RF16
+mission: EUREC4A
+platform: TO
+flight_id: TO-0345
+contacts: []
+date: 2020-02-09
+flight_report: ''
+takeoff: 2020-02-09 10:42:08
+landing: 2020-02-09 14:37:24
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 11:02:12
+  end: 2020-02-09 11:02:12

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209a_0.1.yaml
@@ -17,89 +17,96 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 11:07:48
+  end: 2020-02-09 11:36:57
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 11:39:14
+  end: 2020-02-09 12:12:02
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 12:12:02
+  end: 2020-02-09 12:23:26
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 12:23:26
+  end: 2020-02-09 12:33:54
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 12:37:06
+  end: 2020-02-09 12:41:39
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 12:41:12
+  end: 2020-02-09 12:59:53
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 12:58:03
+  end: 2020-02-09 13:03:59
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 13:03:59
+  end: 2020-02-09 13:08:32
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0345_
-  start: 2020-02-09 11:02:12
-  end: 2020-02-09 11:02:12
+  start: 2020-02-09 13:09:27
+  end: 2020-02-09 13:17:11
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 13:17:11
+  end: 2020-02-09 13:35:52
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 13:37:41
+  end: 2020-02-09 13:52:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 13:55:00
+  end: 2020-02-09 14:04:34
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 14:06:51
+  end: 2020-02-09 14:23:42
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0345_
+  start: 2020-02-09 14:23:15
+  end: 2020-02-09 14:32:22

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209a_0.1.yaml
@@ -14,99 +14,108 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  - cloud
+  name: 'transit_from_circle'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_tr1
   start: 2020-02-09 11:07:48
   end: 2020-02-09 11:36:57
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_cld1
   start: 2020-02-09 11:39:14
   end: 2020-02-09 12:12:02
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_prof1
   start: 2020-02-09 12:12:02
   end: 2020-02-09 12:23:26
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_prof2
   start: 2020-02-09 12:23:26
   end: 2020-02-09 12:33:54
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_prof3
   start: 2020-02-09 12:37:06
   end: 2020-02-09 12:41:39
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_cld2
   start: 2020-02-09 12:41:12
   end: 2020-02-09 12:59:53
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_prof4
   start: 2020-02-09 12:58:03
   end: 2020-02-09 13:03:59
 - kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0345_
-  start: 2020-02-09 13:03:59
-  end: 2020-02-09 13:08:32
-- kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_prof5
   start: 2020-02-09 13:09:27
   end: 2020-02-09 13:17:11
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_bl1
   start: 2020-02-09 13:17:11
   end: 2020-02-09 13:35:52
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_cld3
   start: 2020-02-09 13:37:41
   end: 2020-02-09 13:52:44
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_cld4
   start: 2020-02-09 13:55:00
   end: 2020-02-09 14:04:34
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_cld5
   start: 2020-02-09 14:06:51
   end: 2020-02-09 14:23:42
 - kinds:
   - profile
-  name: ''
+  name: 'profile 6'
   irregularities: []
-  segment_id: TO-0345_
+  segment_id: TO-0345_prof6
   start: 2020-02-09 14:23:15
   end: 2020-02-09 14:32:22
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0345_bco
+  start: 2020-02-09 14:32:00
+  end: 2020-02-09 14:34:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209b_0.1.yaml
@@ -14,92 +14,107 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_tr1
   start: 2020-02-09 15:53:38
   end: 2020-02-09 16:07:37
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_prof1
   start: 2020-02-09 16:07:10
   end: 2020-02-09 16:24:44
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_cld1
   start: 2020-02-09 16:31:30
   end: 2020-02-09 17:07:06
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_prof2
   start: 2020-02-09 17:05:18
   end: 2020-02-09 17:10:42
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_prof3
   start: 2020-02-09 17:10:42
   end: 2020-02-09 17:17:55
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_cld2
   start: 2020-02-09 17:17:01
   end: 2020-02-09 17:37:18
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_cld3
   start: 2020-02-09 17:38:39
   end: 2020-02-09 17:58:28
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_cb1
   start: 2020-02-09 18:00:17
   end: 2020-02-09 18:20:33
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_prof4
   start: 2020-02-09 18:19:39
   end: 2020-02-09 18:28:40
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_bl1
   start: 2020-02-09 18:28:13
   end: 2020-02-09 18:52:33
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_prof5
   start: 2020-02-09 18:52:33
   end: 2020-02-09 18:58:25
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_tr2
   start: 2020-02-09 18:58:25
   end: 2020-02-09 19:03:49
 - kinds:
   - profile
-  name: ''
+  name: 'profile 6'
   irregularities: []
-  segment_id: TO-0346_
+  segment_id: TO-0346_prof6
   start: 2020-02-09 19:03:49
   end: 2020-02-09 19:13:44
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0346_bco
+  start: 2020-02-09 19:13:00
+  end: 2020-02-09 19:15:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209b_0.1.yaml
@@ -17,117 +17,89 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 15:53:38
+  end: 2020-02-09 16:07:37
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 16:07:10
+  end: 2020-02-09 16:24:44
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 16:31:30
+  end: 2020-02-09 17:07:06
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 17:05:18
+  end: 2020-02-09 17:10:42
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 17:10:42
+  end: 2020-02-09 17:17:55
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 17:17:01
+  end: 2020-02-09 17:37:18
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 17:38:39
+  end: 2020-02-09 17:58:28
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 18:00:17
+  end: 2020-02-09 18:20:33
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 18:19:39
+  end: 2020-02-09 18:28:40
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 18:28:13
+  end: 2020-02-09 18:52:33
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 18:52:33
+  end: 2020-02-09 18:58:25
 - kinds:
   - level
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 18:58:25
+  end: 2020-02-09 19:03:49
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0346_
-  start: 2020-02-09 15:45:51
-  end: 2020-02-09 15:45:51
+  start: 2020-02-09 19:03:49
+  end: 2020-02-09 19:13:44

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200209b_0.1.yaml
@@ -1,0 +1,133 @@
+name: RF17
+mission: EUREC4A
+platform: TO
+flight_id: TO-0346
+contacts: []
+date: 2020-02-09
+flight_report: ''
+takeoff: 2020-02-09 15:39:01
+landing: 2020-02-09 19:18:43
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0346_
+  start: 2020-02-09 15:45:51
+  end: 2020-02-09 15:45:51

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200210a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200210a_0.1.yaml
@@ -14,92 +14,107 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_tr1
   start: 2020-02-10 13:02:05
   end: 2020-02-10 13:14:29
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_prof1
   start: 2020-02-10 13:14:29
   end: 2020-02-10 13:24:59
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_bl1
   start: 2020-02-10 13:25:28
   end: 2020-02-10 13:41:12
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_prof2
   start: 2020-02-10 13:40:15
   end: 2020-02-10 13:58:51
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 1'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_saw1
   start: 2020-02-10 13:55:59
   end: 2020-02-10 14:55:36
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_cld1
   start: 2020-02-10 14:53:41
   end: 2020-02-10 15:09:26
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_cld2
   start: 2020-02-10 15:12:17
   end: 2020-02-10 15:18:29
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_cld3
   start: 2020-02-10 15:20:24
   end: 2020-02-10 15:25:39
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_cld4
   start: 2020-02-10 15:26:36
   end: 2020-02-10 15:44:15
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_cld5
   start: 2020-02-10 15:49:58
   end: 2020-02-10 15:58:33
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_prof3
   start: 2020-02-10 15:59:02
   end: 2020-02-10 16:02:22
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_prof4
   start: 2020-02-10 16:01:25
   end: 2020-02-10 16:17:38
 - kinds:
   - profile
-  name: ''
+  name: 'profile 5'
   irregularities: []
-  segment_id: TO-0347_
+  segment_id: TO-0347_prof5
   start: 2020-02-10 16:16:40
   end: 2020-02-10 16:33:22
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0347_bco
+  start: 2020-02-10 16:33:00
+  end: 2020-02-10 16:35:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200210a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200210a_0.1.yaml
@@ -17,89 +17,89 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
+  start: 2020-02-10 13:02:05
+  end: 2020-02-10 13:14:29
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
+  start: 2020-02-10 13:14:29
+  end: 2020-02-10 13:24:59
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 13:25:28
+  end: 2020-02-10 13:41:12
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
+  start: 2020-02-10 13:40:15
+  end: 2020-02-10 13:58:51
 - kinds:
   - sawtooth
   name: ''
   irregularities: []
   segment_id: TO-0347_
-  start: 2020-02-10 12:54:48
-  end: 2020-02-10 12:54:48
+  start: 2020-02-10 13:55:59
+  end: 2020-02-10 14:55:36
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 14:53:41
+  end: 2020-02-10 15:09:26
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 15:12:17
+  end: 2020-02-10 15:18:29
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 15:20:24
+  end: 2020-02-10 15:25:39
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 15:26:36
+  end: 2020-02-10 15:44:15
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 15:49:58
+  end: 2020-02-10 15:58:33
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 15:59:02
+  end: 2020-02-10 16:02:22
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 16:01:25
+  end: 2020-02-10 16:17:38
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 16:16:40
+  end: 2020-02-10 16:33:22

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200210a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200210a_0.1.yaml
@@ -1,0 +1,105 @@
+name: RF18
+mission: EUREC4A
+platform: TO
+flight_id: TO-0347
+contacts: []
+date: 2020-02-10
+flight_report: ''
+takeoff: 2020-02-10 12:45:41
+landing: 2020-02-10 16:41:21
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0347_
+  start: 2020-02-10 12:54:48
+  end: 2020-02-10 12:54:48

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
@@ -93,9 +93,9 @@ segments:
   end: 2020-02-11 15:24:44
 - kinds:
   - profile
-  name: 'profile 2'
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0348_prof2
+  segment_id: TO-0348_prof3
   start: 2020-02-11 15:25:15
   end: 2020-02-11 15:30:07
 - kinds:

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
@@ -1,0 +1,84 @@
+name: RF20
+mission: EUREC4A
+platform: TO
+flight_id: TO-0349
+contacts: []
+date: 2020-02-11
+flight_report: ''
+takeoff: 2020-02-11 17:39:42
+landing: 2020-02-11 21:24:02
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 17:52:21
+  end: 2020-02-11 17:52:21

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
@@ -2,7 +2,11 @@ name: RF19
 mission: EUREC4A
 platform: TO
 flight_id: TO-0348
-contacts: []
+contacts:
+- name: Leo Saffin
+  email: l.saffin@leeds.ac.uk
+  tags:
+    - flight PI
 date: 2020-02-11
 flight_report: ''
 takeoff: 2020-02-11 12:14:59
@@ -14,85 +18,92 @@ remarks:
 segments:
 - kinds:
   - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:39:45
+  name: 'profile 1'
+  irregularities:
+    - Profile starts outside HALO circle
+  segment_id: TO-0348_prof1
+  start: 2020-02-11 12:42:15
   end: 2020-02-11 13:01:13
 - kinds:
   - sawtooth
-  name: ''
+  - cloud
+  - detrainment_layer
+  name: 'sawtooth detrainment layer 1'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_saw1
   start: 2020-02-11 12:54:02
   end: 2020-02-11 13:27:15
 - kinds:
   - level
-  name: ''
+  - cloud
+  - detrainment_layer
+  name: 'level detrainment layer 1'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_level_detr1
   start: 2020-02-11 13:27:15
   end: 2020-02-11 13:45:30
 - kinds:
   - sawtooth
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
+  - cloud
+  - detrainment_layer
+  name: 'sawtooth detrainment layer 2'
+  irregularities:
+    - Originally intented as a straight leg but kept adjusting height to stay with the detrainment layer
+  segment_id: TO-0348_saw2
   start: 2020-02-11 13:44:41
   end: 2020-02-11 14:11:04
 - kinds:
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_prof2
   start: 2020-02-11 14:10:52
   end: 2020-02-11 14:23:58
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_cld1
   start: 2020-02-11 14:25:21
   end: 2020-02-11 14:38:44
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_cld2
   start: 2020-02-11 14:40:31
   end: 2020-02-11 14:52:09
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_cld3
   start: 2020-02-11 14:53:56
   end: 2020-02-11 15:08:15
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_cld4
   start: 2020-02-11 15:09:09
   end: 2020-02-11 15:24:44
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0348_
+  segment_id: TO-0348_prof2
   start: 2020-02-11 15:25:15
   end: 2020-02-11 15:30:07
 - kinds:
   - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
+  - boundary_layer
+  name: 'boundary layer 1'
+  irregularities:
+    - Ends early due to issues with aeroplane
+  segment_id: TO-0348_bl1
   start: 2020-02-11 15:29:43
   end: 2020-02-11 15:40:01
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 15:45:49
-  end: 2020-02-11 15:53:53

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
@@ -1,84 +1,98 @@
-name: RF20
+name: RF19
 mission: EUREC4A
 platform: TO
-flight_id: TO-0349
+flight_id: TO-0348
 contacts: []
 date: 2020-02-11
 flight_report: ''
-takeoff: 2020-02-11 17:39:42
-landing: 2020-02-11 21:24:02
+takeoff: 2020-02-11 12:14:59
+landing: 2020-02-11 16:09:23
 events: []
 remarks:
 - HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
   or H2O_LICOR.
 segments:
 - kinds:
-  - level
+  - profile
   name: ''
   irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
+  segment_id: TO-0348_
+  start: 2020-02-11 12:39:45
+  end: 2020-02-11 13:01:13
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:54:02
+  end: 2020-02-11 13:27:15
 - kinds:
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
+  segment_id: TO-0348_
+  start: 2020-02-11 13:27:15
+  end: 2020-02-11 13:45:30
 - kinds:
-  - level
+  - sawtooth
   name: ''
   irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
+  segment_id: TO-0348_
+  start: 2020-02-11 13:44:41
+  end: 2020-02-11 14:11:04
 - kinds:
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0349_
-  start: 2020-02-11 17:52:21
-  end: 2020-02-11 17:52:21
+  segment_id: TO-0348_
+  start: 2020-02-11 14:10:52
+  end: 2020-02-11 14:23:58
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 14:25:21
+  end: 2020-02-11 14:38:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 14:40:31
+  end: 2020-02-11 14:52:09
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 14:53:56
+  end: 2020-02-11 15:08:15
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 15:09:09
+  end: 2020-02-11 15:24:44
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 15:25:15
+  end: 2020-02-11 15:30:07
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 15:29:43
+  end: 2020-02-11 15:40:01
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 15:45:49
+  end: 2020-02-11 15:53:53

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211a_0.1.yaml
@@ -54,7 +54,7 @@ segments:
   end: 2020-02-11 14:11:04
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
   segment_id: TO-0348_prof2
   start: 2020-02-11 14:10:52

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211b_0.1.yaml
@@ -1,12 +1,12 @@
-name: RF19
+name: RF20
 mission: EUREC4A
 platform: TO
-flight_id: TO-0348
+flight_id: TO-0349
 contacts: []
 date: 2020-02-11
 flight_report: ''
-takeoff: 2020-02-11 12:14:59
-landing: 2020-02-11 16:09:23
+takeoff: 2020-02-11 17:39:42
+landing: 2020-02-11 21:24:02
 events: []
 remarks:
 - HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
@@ -16,76 +16,90 @@ segments:
   - level
   name: ''
   irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
+  segment_id: TO-0349_
+  start: 2020-02-11 18:05:55
+  end: 2020-02-11 18:31:55
 - kinds:
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
+  segment_id: TO-0349_
+  start: 2020-02-11 18:31:01
+  end: 2020-02-11 18:40:26
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 18:39:59
+  end: 2020-02-11 19:03:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 19:06:25
+  end: 2020-02-11 19:30:11
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 19:31:58
+  end: 2020-02-11 19:43:10
 - kinds:
   - profile
   name: ''
   irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
+  segment_id: TO-0349_
+  start: 2020-02-11 19:42:17
+  end: 2020-02-11 19:47:12
 - kinds:
-  - sawtooth
+  - level
   name: ''
   irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
+  segment_id: TO-0349_
+  start: 2020-02-11 19:46:46
+  end: 2020-02-11 19:54:50
 - kinds:
-  - sawtooth
+  - level
   name: ''
   irregularities: []
-  segment_id: TO-0348_
-  start: 2020-02-11 12:32:44
-  end: 2020-02-11 12:32:44
+  segment_id: TO-0349_
+  start: 2020-02-11 19:57:04
+  end: 2020-02-11 20:08:43
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 20:08:43
+  end: 2020-02-11 20:11:24
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 20:11:24
+  end: 2020-02-11 20:29:47
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 20:28:53
+  end: 2020-02-11 20:32:55
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 20:32:55
+  end: 2020-02-11 20:49:57
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0349_
+  start: 2020-02-11 20:49:57
+  end: 2020-02-11 21:19:32

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211b_0.1.yaml
@@ -1,0 +1,91 @@
+name: RF19
+mission: EUREC4A
+platform: TO
+flight_id: TO-0348
+contacts: []
+date: 2020-02-11
+flight_report: ''
+takeoff: 2020-02-11 12:14:59
+landing: 2020-02-11 16:09:23
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0348_
+  start: 2020-02-11 12:32:44
+  end: 2020-02-11 12:32:44

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200211b_0.1.yaml
@@ -14,92 +14,102 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  - cloud
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_tr1
   start: 2020-02-11 18:05:55
   end: 2020-02-11 18:31:55
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_prof1
   start: 2020-02-11 18:31:01
   end: 2020-02-11 18:40:26
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_bl1
   start: 2020-02-11 18:39:59
   end: 2020-02-11 19:03:17
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_bl2
   start: 2020-02-11 19:06:25
   end: 2020-02-11 19:30:11
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_cld1
   start: 2020-02-11 19:31:58
   end: 2020-02-11 19:43:10
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_prof2
   start: 2020-02-11 19:42:17
   end: 2020-02-11 19:47:12
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_cld2
   start: 2020-02-11 19:46:46
   end: 2020-02-11 19:54:50
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_cld3
   start: 2020-02-11 19:57:04
   end: 2020-02-11 20:08:43
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_prof3
   start: 2020-02-11 20:08:43
   end: 2020-02-11 20:11:24
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_cld4
   start: 2020-02-11 20:11:24
   end: 2020-02-11 20:29:47
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_prof4
   start: 2020-02-11 20:28:53
   end: 2020-02-11 20:32:55
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_cld5
   start: 2020-02-11 20:32:55
   end: 2020-02-11 20:49:57
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 6'
   irregularities: []
-  segment_id: TO-0349_
+  segment_id: TO-0349_cld6
   start: 2020-02-11 20:49:57
   end: 2020-02-11 21:19:32

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213a_0.1.yaml
@@ -17,96 +17,117 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
+  start: 2020-02-13 12:00:41
+  end: 2020-02-13 12:16:09
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
+  start: 2020-02-13 12:15:41
+  end: 2020-02-13 12:24:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 12:25:41
+  end: 2020-02-13 12:59:47
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
+  start: 2020-02-13 12:59:47
+  end: 2020-02-13 13:03:26
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 13:02:04
+  end: 2020-02-13 13:13:53
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 13:17:31
+  end: 2020-02-13 13:36:37
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 13:37:59
+  end: 2020-02-13 13:49:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 13:52:05
+  end: 2020-02-13 14:01:10
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 14:04:21
+  end: 2020-02-13 14:19:49
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0350_
-  start: 2020-02-13 11:55:33
-  end: 2020-02-13 11:55:33
+  start: 2020-02-13 14:20:16
+  end: 2020-02-13 14:24:49
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 14:26:11
+  end: 2020-02-13 14:31:11
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 14:29:49
+  end: 2020-02-13 14:34:22
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 14:33:27
+  end: 2020-02-13 14:41:11
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 14:47:06
+  end: 2020-02-13 14:58:55
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 14:58:55
+  end: 2020-02-13 15:02:06
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 15:01:39
+  end: 2020-02-13 15:05:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 15:08:28
+  end: 2020-02-13 15:23:01

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213a_0.1.yaml
@@ -1,0 +1,112 @@
+name: RF21
+mission: EUREC4A
+platform: TO
+flight_id: TO-0350
+contacts: []
+date: 2020-02-13
+flight_report: ''
+takeoff: 2020-02-13 11:38:57
+landing: 2020-02-13 15:30:18
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0350_
+  start: 2020-02-13 11:55:33
+  end: 2020-02-13 11:55:33

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213a_0.1.yaml
@@ -14,120 +14,125 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_tr1
   start: 2020-02-13 12:00:41
   end: 2020-02-13 12:16:09
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_prof1
   start: 2020-02-13 12:15:41
   end: 2020-02-13 12:24:20
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_bl1
   start: 2020-02-13 12:25:41
   end: 2020-02-13 12:59:47
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_prof2
   start: 2020-02-13 12:59:47
   end: 2020-02-13 13:03:26
 - kinds:
   - level
-  name: ''
+  - cloud_base
+  name: 'cloud base 1'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cb1
   start: 2020-02-13 13:02:04
   end: 2020-02-13 13:13:53
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld1
   start: 2020-02-13 13:17:31
   end: 2020-02-13 13:36:37
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld2
   start: 2020-02-13 13:37:59
   end: 2020-02-13 13:49:21
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld3
   start: 2020-02-13 13:52:05
   end: 2020-02-13 14:01:10
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld4
   start: 2020-02-13 14:04:21
   end: 2020-02-13 14:19:49
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_prof3
   start: 2020-02-13 14:20:16
   end: 2020-02-13 14:24:49
 - kinds:
   - level
-  name: ''
+  - above_cloud
+  name: 'above cloud 1'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_ac1
   start: 2020-02-13 14:26:11
   end: 2020-02-13 14:31:11
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_prof4
   start: 2020-02-13 14:29:49
   end: 2020-02-13 14:34:22
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld5
   start: 2020-02-13 14:33:27
   end: 2020-02-13 14:41:11
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 6'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld6
   start: 2020-02-13 14:47:06
   end: 2020-02-13 14:58:55
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0350_
-  start: 2020-02-13 14:58:55
-  end: 2020-02-13 15:02:06
-- kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 7'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld7
   start: 2020-02-13 15:01:39
   end: 2020-02-13 15:05:17
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 8'
   irregularities: []
-  segment_id: TO-0350_
+  segment_id: TO-0350_cld8
   start: 2020-02-13 15:08:28
   end: 2020-02-13 15:23:01

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213b_0.1.yaml
@@ -14,113 +14,116 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_tr1
   start: 2020-02-13 17:27:01
   end: 2020-02-13 17:44:48
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_prof1
   start: 2020-02-13 17:42:15
   end: 2020-02-13 17:49:52
 - kinds:
   - sawtooth
-  name: ''
+  name: 'sawtooth 1'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_saw1
   start: 2020-02-13 17:48:36
   end: 2020-02-13 17:56:13
 - kinds:
   - level
-  name: ''
+  - above_cloud
+  name: 'above cloud 1'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_ac1
   start: 2020-02-13 17:55:48
   end: 2020-02-13 18:00:53
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_prof2
   start: 2020-02-13 18:00:27
   end: 2020-02-13 18:14:26
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_prof3
   start: 2020-02-13 18:14:26
   end: 2020-02-13 18:19:56
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld1
   start: 2020-02-13 18:22:28
   end: 2020-02-13 18:34:19
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 18:33:54
-  end: 2020-02-13 18:37:42
-- kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld2
   start: 2020-02-13 18:36:52
   end: 2020-02-13 18:41:31
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld3
   start: 2020-02-13 18:44:54
   end: 2020-02-13 18:53:48
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld4
   start: 2020-02-13 18:55:04
   end: 2020-02-13 19:11:34
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld5
   start: 2020-02-13 19:14:07
   end: 2020-02-13 19:24:16
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 6'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld6
   start: 2020-02-13 19:25:07
   end: 2020-02-13 19:47:59
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 7'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld7
   start: 2020-02-13 19:54:20
   end: 2020-02-13 20:00:41
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 8'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_cld8
   start: 2020-02-13 20:03:38
   end: 2020-02-13 20:14:13
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0351_
+  segment_id: TO-0351_prof4
   start: 2020-02-13 20:11:41
   end: 2020-02-13 20:18:27

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213b_0.1.yaml
@@ -1,0 +1,105 @@
+name: RF22
+mission: EUREC4A
+platform: TO
+flight_id: TO-0351
+contacts: []
+date: 2020-02-13
+flight_report: ''
+takeoff: 2020-02-13 16:59:21
+landing: 2020-02-13 20:31:37
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:10:23
+  end: 2020-02-13 17:10:23

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200213b_0.1.yaml
@@ -17,89 +17,110 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
+  start: 2020-02-13 17:27:01
+  end: 2020-02-13 17:44:48
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
+  start: 2020-02-13 17:42:15
+  end: 2020-02-13 17:49:52
+- kinds:
+  - sawtooth
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:48:36
+  end: 2020-02-13 17:56:13
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 17:55:48
+  end: 2020-02-13 18:00:53
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
+  start: 2020-02-13 18:00:27
+  end: 2020-02-13 18:14:26
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0351_
-  start: 2020-02-13 17:10:23
-  end: 2020-02-13 17:10:23
+  start: 2020-02-13 18:14:26
+  end: 2020-02-13 18:19:56
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 18:22:28
+  end: 2020-02-13 18:34:19
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 18:33:54
+  end: 2020-02-13 18:37:42
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 18:36:52
+  end: 2020-02-13 18:41:31
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 18:44:54
+  end: 2020-02-13 18:53:48
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 18:55:04
+  end: 2020-02-13 19:11:34
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 19:14:07
+  end: 2020-02-13 19:24:16
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 19:25:07
+  end: 2020-02-13 19:47:59
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 19:54:20
+  end: 2020-02-13 20:00:41
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 20:03:38
+  end: 2020-02-13 20:14:13
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0351_
+  start: 2020-02-13 20:11:41
+  end: 2020-02-13 20:18:27

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200214a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200214a_0.1.yaml
@@ -1,0 +1,126 @@
+name: RF23
+mission: EUREC4A
+platform: TO
+flight_id: TO-0352
+contacts: []
+date: 2020-02-14
+flight_report: ''
+takeoff: 2020-02-14 12:44:05
+landing: 2020-02-14 16:29:01
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 12:56:17
+  end: 2020-02-14 12:56:17

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200214a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200214a_0.1.yaml
@@ -14,106 +14,112 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_tr1
   start: 2020-02-14 13:02:43
   end: 2020-02-14 13:35:36
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_prof1
   start: 2020-02-14 13:35:09
   end: 2020-02-14 13:45:03
 - kinds:
   - level
-  name: ''
+  - above_cloud
+  name: 'above cloud 1'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_ac1
   start: 2020-02-14 13:44:36
   end: 2020-02-14 13:57:40
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 13:56:19
-  end: 2020-02-14 13:59:55
-- kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_cld1
   start: 2020-02-14 13:59:28
   end: 2020-02-14 14:03:59
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_cld2
   start: 2020-02-14 14:06:14
   end: 2020-02-14 14:10:17
 - kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 14:09:23
-  end: 2020-02-14 14:13:26
-- kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_cld3
   start: 2020-02-14 14:13:53
   end: 2020-02-14 14:31:27
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_cld4
   start: 2020-02-14 14:33:42
   end: 2020-02-14 14:47:13
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_cld5
   start: 2020-02-14 14:51:43
   end: 2020-02-14 15:05:14
 - kinds:
   - level
-  name: ''
+  - rain_shafts
+  name: 'rain shaft chasing'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_rain
   start: 2020-02-14 15:06:35
   end: 2020-02-14 15:20:06
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_bl1
   start: 2020-02-14 15:19:39
   end: 2020-02-14 15:42:37
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_bl2
   start: 2020-02-14 15:45:19
   end: 2020-02-14 15:57:02
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 3'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_bl3
   start: 2020-02-14 15:59:44
   end: 2020-02-14 16:10:05
 - kinds:
   - level
-  name: ''
+  - transit
+  name: 'transit from circle'
   irregularities: []
-  segment_id: TO-0352_
+  segment_id: TO-0352_tr2
   start: 2020-02-14 16:11:54
   end: 2020-02-14 16:25:24
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0352_bco
+  start: 2020-02-14 16:25:00
+  end: 2020-02-14 16:27:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200214a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200214a_0.1.yaml
@@ -17,110 +17,103 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
+  start: 2020-02-14 13:02:43
+  end: 2020-02-14 13:35:36
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
+  start: 2020-02-14 13:35:09
+  end: 2020-02-14 13:45:03
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 13:44:36
+  end: 2020-02-14 13:57:40
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
+  start: 2020-02-14 13:56:19
+  end: 2020-02-14 13:59:55
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 13:59:28
+  end: 2020-02-14 14:03:59
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 14:06:14
+  end: 2020-02-14 14:10:17
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
+  start: 2020-02-14 14:09:23
+  end: 2020-02-14 14:13:26
 - kinds:
-  - profile
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0352_
-  start: 2020-02-14 12:56:17
-  end: 2020-02-14 12:56:17
+  start: 2020-02-14 14:13:53
+  end: 2020-02-14 14:31:27
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 14:33:42
+  end: 2020-02-14 14:47:13
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 14:51:43
+  end: 2020-02-14 15:05:14
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 15:06:35
+  end: 2020-02-14 15:20:06
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 15:19:39
+  end: 2020-02-14 15:42:37
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 15:45:19
+  end: 2020-02-14 15:57:02
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 15:59:44
+  end: 2020-02-14 16:10:05
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0352_
+  start: 2020-02-14 16:11:54
+  end: 2020-02-14 16:25:24

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215a_0.1.yaml
@@ -17,82 +17,103 @@ segments:
   name: ''
   irregularities: []
   segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
+  start: 2020-02-15 12:03:32
+  end: 2020-02-15 12:26:38
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
+  start: 2020-02-15 12:26:12
+  end: 2020-02-15 12:36:51
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 12:36:25
+  end: 2020-02-15 12:51:58
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 12:52:51
+  end: 2020-02-15 13:07:57
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 13:09:17
+  end: 2020-02-15 13:26:37
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 13:27:03
+  end: 2020-02-15 13:43:29
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 13:45:16
+  end: 2020-02-15 14:00:22
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 14:01:42
+  end: 2020-02-15 14:17:42
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
+  start: 2020-02-15 14:17:42
+  end: 2020-02-15 14:27:01
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
+  start: 2020-02-15 14:27:01
+  end: 2020-02-15 14:33:15
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 14:32:48
+  end: 2020-02-15 14:39:28
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 14:40:21
+  end: 2020-02-15 14:50:34
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 14:51:54
+  end: 2020-02-15 15:00:21
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 15:00:47
+  end: 2020-02-15 15:11:27
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0353_
-  start: 2020-02-15 11:57:38
-  end: 2020-02-15 11:57:38
+  start: 2020-02-15 15:11:54
+  end: 2020-02-15 15:25:13

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215a_0.1.yaml
@@ -1,0 +1,98 @@
+name: RF24
+mission: EUREC4A
+platform: TO
+flight_id: TO-0353
+contacts: []
+date: 2020-02-15
+flight_report: ''
+takeoff: 2020-02-15 11:44:36
+landing: 2020-02-15 15:27:27
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0353_
+  start: 2020-02-15 11:57:38
+  end: 2020-02-15 11:57:38

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215a_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215a_0.1.yaml
@@ -14,106 +14,126 @@ remarks:
 segments:
 - kinds:
   - level
-  name: ''
+  - transit
+  - cloud
+  name: 'transit to circle'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_tr1
   start: 2020-02-15 12:03:32
   end: 2020-02-15 12:26:38
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_prof1
   start: 2020-02-15 12:26:12
   end: 2020-02-15 12:36:51
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_bl1a
   start: 2020-02-15 12:36:25
   end: 2020-02-15 12:51:58
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_bl1b
   start: 2020-02-15 12:52:51
   end: 2020-02-15 13:07:57
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2a'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_bl2a
   start: 2020-02-15 13:09:17
   end: 2020-02-15 13:26:37
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2b'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_bl2b
   start: 2020-02-15 13:27:03
   end: 2020-02-15 13:43:29
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 3a'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_bl3a
   start: 2020-02-15 13:45:16
   end: 2020-02-15 14:00:22
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 3b'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_bl3b
   start: 2020-02-15 14:01:42
   end: 2020-02-15 14:17:42
 - kinds:
   - profile
-  name: ''
+  name: 'profile 2'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_prof2
   start: 2020-02-15 14:17:42
   end: 2020-02-15 14:27:01
 - kinds:
   - profile
-  name: ''
+  name: 'profile 3'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_prof3
   start: 2020-02-15 14:27:01
   end: 2020-02-15 14:33:15
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_cld1
   start: 2020-02-15 14:32:48
   end: 2020-02-15 14:39:28
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_cld2
   start: 2020-02-15 14:40:21
   end: 2020-02-15 14:50:34
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_cld3
   start: 2020-02-15 14:51:54
   end: 2020-02-15 15:00:21
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_cld4
   start: 2020-02-15 15:00:47
   end: 2020-02-15 15:11:27
 - kinds:
   - profile
-  name: ''
+  name: 'profile 4'
   irregularities: []
-  segment_id: TO-0353_
+  segment_id: TO-0353_prof4
   start: 2020-02-15 15:11:54
   end: 2020-02-15 15:25:13
+- kinds:
+  - level
+  - bco_flyby
+  name: 'BCO flyby'
+  irregularities: []
+  segment_id: TO-0353_bco
+  start: 2020-02-15 15:25:00
+  end: 2020-02-15 15:27:00

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
@@ -2,7 +2,11 @@ name: RF25
 mission: EUREC4A
 platform: TO
 flight_id: TO-0354
-contacts: []
+contacts:
+- name: Leo Saffin
+  email: l.saffin@leeds.ac.uk
+  tags:
+  - flight PI
 date: 2020-02-15
 flight_report: ''
 takeoff: 2020-02-15 16:39:53

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
@@ -14,85 +14,89 @@ remarks:
 segments:
 - kinds:
   - profile
-  name: ''
+  name: 'profile 1'
   irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:54:05
-  end: 2020-02-15 17:09:05
-- kinds:
-  - profile
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_prof1
   start: 2020-02-15 17:10:27
   end: 2020-02-15 17:24:32
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1a'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_bl1a
   start: 2020-02-15 17:24:32
   end: 2020-02-15 17:41:20
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 1b'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_bl1b
   start: 2020-02-15 17:41:48
   end: 2020-02-15 17:55:25
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 2a'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_bl2a
   start: 2020-02-15 17:58:09
   end: 2020-02-15 18:11:19
 - kinds:
   - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
+  - boundary_layer
+  name: 'boundary layer 2b'
+  irregularities:
+    - Spike in CPC associated with ship exhaust
+  segment_id: TO-0354_bl2b
   start: 2020-02-15 18:13:36
   end: 2020-02-15 18:26:46
 - kinds:
   - level
-  name: ''
+  - boundary_layer
+  name: 'boundary layer 3'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_bl3
   start: 2020-02-15 18:28:08
   end: 2020-02-15 18:43:07
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 1'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_cld1
   start: 2020-02-15 18:46:18
   end: 2020-02-15 19:08:34
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 2'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_cld2
   start: 2020-02-15 19:09:55
   end: 2020-02-15 19:29:28
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 3'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_cld3
   start: 2020-02-15 19:30:22
   end: 2020-02-15 19:46:43
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 4'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_cld4
   start: 2020-02-15 19:46:43
   end: 2020-02-15 19:56:16
 - kinds:
   - level
-  name: ''
+  - cloud
+  name: 'cloud 5'
   irregularities: []
-  segment_id: TO-0354_
+  segment_id: TO-0354_cld5
   start: 2020-02-15 19:58:59
   end: 2020-02-15 20:17:37

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
@@ -1,0 +1,84 @@
+name: RF25
+mission: EUREC4A
+platform: TO
+flight_id: TO-0354
+contacts: []
+date: 2020-02-15
+flight_report: ''
+takeoff: 2020-02-15 16:39:53
+landing: 2020-02-15 20:23:59
+events: []
+remarks:
+- HUM_ROSE is not well calibrated to absolute values - reference against TDEW_BUCK
+  or H2O_LICOR.
+segments:
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25
+- kinds:
+  - profile
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 16:49:25
+  end: 2020-02-15 16:49:25

--- a/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
+++ b/flight_phase_files/TO/EUREC4A_TO_Flight-Segments_20200215b_0.1.yaml
@@ -13,72 +13,86 @@ remarks:
   or H2O_LICOR.
 segments:
 - kinds:
-  - level
+  - profile
   name: ''
   irregularities: []
   segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
-- kinds:
-  - level
-  name: ''
-  irregularities: []
-  segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
+  start: 2020-02-15 16:54:05
+  end: 2020-02-15 17:09:05
 - kinds:
   - profile
   name: ''
   irregularities: []
   segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
+  start: 2020-02-15 17:10:27
+  end: 2020-02-15 17:24:32
 - kinds:
-  - profile
+  - level
   name: ''
   irregularities: []
   segment_id: TO-0354_
-  start: 2020-02-15 16:49:25
-  end: 2020-02-15 16:49:25
+  start: 2020-02-15 17:24:32
+  end: 2020-02-15 17:41:20
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 17:41:48
+  end: 2020-02-15 17:55:25
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 17:58:09
+  end: 2020-02-15 18:11:19
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 18:13:36
+  end: 2020-02-15 18:26:46
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 18:28:08
+  end: 2020-02-15 18:43:07
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 18:46:18
+  end: 2020-02-15 19:08:34
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 19:09:55
+  end: 2020-02-15 19:29:28
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 19:30:22
+  end: 2020-02-15 19:46:43
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 19:46:43
+  end: 2020-02-15 19:56:16
+- kinds:
+  - level
+  name: ''
+  irregularities: []
+  segment_id: TO-0354_
+  start: 2020-02-15 19:58:59
+  end: 2020-02-15 20:17:37

--- a/scripts/checkers.py
+++ b/scripts/checkers.py
@@ -30,6 +30,7 @@ class FlightChecker:
                 yield "segment_id \"{}\" is duplicated".format(segment_id)
             self.used_segment_ids.add(segment_id)
         else:
+            segment_id = ""
             yield "segment_id is missing"
 
         if "kinds" in seg:
@@ -67,7 +68,9 @@ class FlightChecker:
             good_dropsondes = seg["good_dropsondes"]
 
         if "dropsondes" not in seg:
-            yield "dropsondes attribute is missing"
+            # Only expect the dropsonde attribute from HALO and P3
+            if "HALO-" in segment_id or "P3-" in segment_id:
+                yield "dropsondes attribute is missing"
         elif not isinstance(seg["dropsondes"], dict):
             yield "dropsondes is not a mapping"
         else:

--- a/scripts/navdata.py
+++ b/scripts/navdata.py
@@ -51,11 +51,9 @@ def get_navdata_TO(nav_data):
     """
     :param nav_data: flight id
     """
-    import pathlib
     import xarray as xr
-    import twinotter
 
-    ds = twinotter.load_flight(nav_data)
+    ds = xr.open_dataset(nav_data)
     ds = ds.rename(dict(Time="time"))
 
     return xr.Dataset({

--- a/scripts/navdata.py
+++ b/scripts/navdata.py
@@ -26,8 +26,30 @@ def get_navdata_HALO(flight):
         "heading": ds.IRS_HDG,
     })
 
+def get_navdata_TO(nav_data):
+    """
+    :param nav_data: flight id
+    """
+    import pathlib
+    import xarray as xr
+    import twinotter
+
+    ds = twinotter.load_flight(nav_data)
+    ds = ds.rename(dict(Time="time"))
+
+    return xr.Dataset({
+        "time": ds.time,
+        "lat": ds.LAT_OXTS,
+        "lon": ds.LON_OXTS,
+        "alt": ds.ALT_OXTS,
+        "roll": ds.ROLL_OXTS,
+        "pitch": ds.PTCH_OXTS,
+        "heading": ds.HDG_OXTS,
+    })
+
 NAVDATA_GETTERS = {
     "HALO": get_navdata_HALO,
+    "TO": get_navdata_TO,
 }
 
 def get_navdata(platform, flight):

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -335,7 +335,7 @@ def _main():
         sondes_by_flag = {f: [s for s in sondes_in_segment if s["flag"] == f]
                           for f in set(s["flag"] for s in sondes_in_segment)}
 
-        manual_sondes_by_flag = {f: [sondes_by_id[s] for s in sondes] for f, sondes in seg.get("dropsondes", []).items()}
+        manual_sondes_by_flag = {f: [sondes_by_id[s] for s in sondes] for f, sondes in seg.get("dropsondes", {}).items()}
 
         seg["sondes_by_flag"] = sondes_by_flag
 

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -1,3 +1,9 @@
+"""
+Usage:
+    report.py <infile.yml> <outfile.html> [-s <sondes.yml>]
+"""
+
+
 import os
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 import yaml
@@ -198,6 +204,7 @@ def _main():
     parser.add_argument("infile")
     parser.add_argument("outfile")
     parser.add_argument("-s", "--sonde_info", help="sonde info yaml file", default=os.path.join(basedir, "sondes.yaml"))
+    parser.add_argument("-n", "--nav_data", help="local file with flight coordinates", default=None)
     args = parser.parse_args()
 
     flightdata = yaml.load(open(args.infile), Loader=yaml.SafeLoader)
@@ -214,7 +221,10 @@ def _main():
         sonde_info = []
         global_warnings.append("no sonde_info is specified, using data from unified dataset")
 
-    navdata = get_navdata(platform, flight_id).load()
+    if args.nav_data is None:
+        navdata = get_navdata(platform, flight_id).load()
+    else:
+        navdata = get_navdata(platform, args.nav_data).load()
 
     sonde_info = [s for s in sonde_info if s["platform"] == platform]
     sondes_by_id = {s["sonde_id"]: s for s in sonde_info}


### PR DESCRIPTION
I've added preliminary yaml files roughly categorising the segments in twin otter flights. It's not ready to merge yet as the files I've used aren't finalised or openly available yet so I can't put in the corresponding changes to the report/validate scripts. I thought it would be good to have this as an open pull request just to show these files are available if needed.