### PR TITLE
add irregularities to circles without sondes

### DIFF
--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
@@ -133,7 +133,7 @@ segments:
   - circle
   name: circle 4
   irregularities:
-  - TTFS circle without any sondes due to lack of dropsonde during final research flight
+  - planned sondeless circle
   segment_id: HALO-0215_c4
   start: 2020-02-15 20:11:45
   end: 2020-02-15 21:19:40

--- a/flight_phase_files/P3/EUREC4A_ATOMIC_P3_Flight-segments_20200124_v0.5.yaml
+++ b/flight_phase_files/P3/EUREC4A_ATOMIC_P3_Flight-segments_20200124_v0.5.yaml
@@ -41,7 +41,8 @@ segments:
 - name: circle 1
   start: 2020-01-24 13:35:00
   end: 2020-01-24 14:47:42
-  irregularities: []
+  irregularities: 
+  - TTFS circle without any sondes 
   segment_id: P3-0124_ci1
   kinds:
   - circle
@@ -52,7 +53,8 @@ segments:
 - name: circle 2
   start: 2020-01-24 14:47:42
   end: 2020-01-24 15:58:48
-  irregularities: []
+  irregularities: 
+  - TTFS circle without any sondes 
   segment_id: P3-0124_ci2
   kinds:
   - circle
@@ -63,7 +65,8 @@ segments:
 - name: half-circle 3
   start: 2020-01-24 15:58:48
   end: 2020-01-24 16:34:30
-  irregularities: []
+  irregularities: 
+  - TTFS circle without any sondes 
   segment_id: P3-0124_ci3
   kinds:
   - circle

--- a/flight_phase_files/P3/EUREC4A_ATOMIC_P3_Flight-segments_20200124_v0.5.yaml
+++ b/flight_phase_files/P3/EUREC4A_ATOMIC_P3_Flight-segments_20200124_v0.5.yaml
@@ -67,6 +67,7 @@ segments:
   end: 2020-01-24 16:34:30
   irregularities: 
   - planned sondeless circle
+  - circle does not fulfil the definition of 360 degree
   segment_id: P3-0124_ci3
   kinds:
   - circle

--- a/flight_phase_files/P3/EUREC4A_ATOMIC_P3_Flight-segments_20200124_v0.5.yaml
+++ b/flight_phase_files/P3/EUREC4A_ATOMIC_P3_Flight-segments_20200124_v0.5.yaml
@@ -42,7 +42,7 @@ segments:
   start: 2020-01-24 13:35:00
   end: 2020-01-24 14:47:42
   irregularities: 
-  - TTFS circle without any sondes 
+  - planned sondeless circle
   segment_id: P3-0124_ci1
   kinds:
   - circle
@@ -54,7 +54,7 @@ segments:
   start: 2020-01-24 14:47:42
   end: 2020-01-24 15:58:48
   irregularities: 
-  - TTFS circle without any sondes 
+  - planned sondeless circle
   segment_id: P3-0124_ci2
   kinds:
   - circle
@@ -66,7 +66,7 @@ segments:
   start: 2020-01-24 15:58:48
   end: 2020-01-24 16:34:30
   irregularities: 
-  - TTFS circle without any sondes 
+  - planned sondeless circle
   segment_id: P3-0124_ci3
   kinds:
   - circle


### PR DESCRIPTION
The circles of P3 without any sonde launches have irregularities added as "TTFS circle without any sondes". This is for JOANNE to auto-detect which circles to pick for Level-4.

Additional question:

Should the half-circle have a different kind, since it doesn't follow the definition? Or should it be mentioned as an irregularity 