### PR TITLE
add irregularities for circles HALO-0119_c1 and HALO-0215_c3

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ Currently the following *irregularity tags* are in use:
 
 * `TTFS`: **T**ime **T**o **F**irst **S**onde is (on purpose) not one minute
 * `SAM`: **S**onde **A**dded **M**anually: association of sondes to segments is (on purpose) not as suggested by launch time and segment times
+* * `NONSTD`: segment is not at its usual location or size (only added if there is a usual location or size for this segment `kind` on that `platform`)

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Currently the following *irregularity tags* are in use:
 
 * `TTFS`: **T**ime **T**o **F**irst **S**onde is (on purpose) not one minute
 * `SAM`: **S**onde **A**dded **M**anually: association of sondes to segments is (on purpose) not as suggested by launch time and segment times
-* * `NONSTD`: segment is not at its usual location or size (only added if there is a usual location or size for this segment `kind` on that `platform`)
+* `NONSTD`: segment is not at its usual location or size (only added if there is a usual location or size for this segment `kind` on that `platform`)

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200119.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200119.yaml
@@ -61,6 +61,8 @@ segments:
   name: circle 1
   irregularities:
   - TTFS Start of circle directly with first dropsonde, roll angle around 4 deg in beginning
+  - circle radius is only 92.5 km, western edge aligns with standard circle
+  - center ca. 13.2858, -57.8989
   segment_id: HALO-0119_c1
   start: 2020-01-19 17:33:12
   end: 2020-01-19 18:24:15

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200119.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200119.yaml
@@ -61,8 +61,7 @@ segments:
   name: circle 1
   irregularities:
   - TTFS Start of circle directly with first dropsonde, roll angle around 4 deg in beginning
-  - circle radius is only 92.5 km, western edge aligns with standard circle
-  - center ca. 13.2858, -57.8989
+  - NONSTD circle radius is only 92.5 km, western edge aligns with standard circle, center ca. 13.2858, -57.8989
   segment_id: HALO-0119_c1
   start: 2020-01-19 17:33:12
   end: 2020-01-19 18:24:15

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
@@ -99,8 +99,7 @@ segments:
   - TTFS starts at launch-time of first dropsonde due to high roll before
   - circle ranges over only 359.5 deg in heading
   - change from FL370 to FL180
-  - 620 km upstream of regular circle location
-  - center ca. 13.8999, -52.0352, radius 111 km
+  - NONSTD 620 km upstream of regular circle location, center ca. 13.8999, -52.0352, radius 111 km
   segment_id: HALO-0215_c3
   start: 2020-02-15 18:17:29
   end: 2020-02-15 19:22:05
@@ -281,7 +280,7 @@ segments:
 - kinds:
   - circling
   name: circling 3
-  irregularities: []
+  irregularities: [] 
   segment_id: HALO-0215_o3
   start: 2020-02-15 20:11:45
   end: 2020-02-15 21:19:40

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
@@ -99,6 +99,8 @@ segments:
   - TTFS starts at launch-time of first dropsonde due to high roll before
   - circle ranges over only 359.5 deg in heading
   - change from FL370 to FL180
+  - 620 km upstream of regular circle location
+  - center ca. 13.8999, -52.0352, radius 111 km
   segment_id: HALO-0215_c3
   start: 2020-02-15 18:17:29
   end: 2020-02-15 19:22:05
@@ -279,7 +281,7 @@ segments:
 - kinds:
   - circling
   name: circling 3
-  irregularities: [] 
+  irregularities: []
   segment_id: HALO-0215_o3
   start: 2020-02-15 20:11:45
   end: 2020-02-15 21:19:40


### PR DESCRIPTION
### Circles that deviate from the standard HALO circle

The usual HALO circle was defined by the center at 13.3, -57.717 with a radius of 111 km. Two HALO circles deviated from the standard plan: HALO-0119_c1 and HALO-0215_c3. HALO-0119_c1 was flown with a smaller radius of ca. 92.5 km with the center at ca. 13.2858, -57.8989. HALO-0215_c3 was flown upstream of the usual circle location at ca. 13.8999, -52.0352 but with the standard radius of 111 km.

These exceptions have been added as irregularities to the respective yaml files.

Attached are two figures of the two circles. Gray is the planned "standard HALO circle" and blue the actual flight track. 
![HALO-0119_c1](https://user-images.githubusercontent.com/26898400/108965885-bedbd680-767d-11eb-9827-7275bf059963.png)

![HALO-0215_c3](https://user-images.githubusercontent.com/26898400/108965886-bf746d00-767d-11eb-823f-55ef82d942ef.png)

