### PR TITLE
add NONSTD to sondeless circle in HALO-0215

### DIFF
--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
@@ -134,7 +134,7 @@ segments:
   - circle
   name: circle 4
   irregularities:
-  - planned sondeless circle
+  - NONSTD planned sondeless circle
   segment_id: HALO-0215_c4
   start: 2020-02-15 20:11:45
   end: 2020-02-15 21:19:40


### PR DESCRIPTION
Added the `NONSTD` tag to HALO-0215_c4. The circle had no dropsonde launches. 