### PR TITLE
exclude fsspec version 0.9.0 which has a bug leading to incomplete HTTP reads

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,6 +5,7 @@ pyyaml
 xarray
 requests
 aiohttp
+fsspec!=0.9.0 # 0.9.0 has a bug which leads to incomplete reads via HTTP
 intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 intake-xarray>=0.3.2
 pydap


### PR DESCRIPTION
fsspec 0.9.0 can sometimes return incomplete files when read via HTTP