### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The ATR uses the following sub-kinds of certain `level` segments:
 * below inversion ferry leg
 
 HALO uses the following sub-kinds of the `calibration` kind:
-* lidar_calibration
+* lidar_leg
 * radar_calibration_wiggle
 * radar_calibration_tilted
 * baccardi_calibration


### PR DESCRIPTION
Change name of lidar leg in README.md from lidar_calibration to lidar_leg. That is the kind that is currently used in the HALO flight segment files for these type of segments.