### PR TITLE
sort keys in compiled yaml file in human friendly order

### DIFF
--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -3,6 +3,39 @@ import yaml
 from collections import defaultdict
 
 
+flight_key_priority = [
+    "flight_id",
+    "name",
+    "nickname",
+    "date",
+    "platform",
+    "mission",
+    "takeoff",
+    "landing",
+    "flight_report",
+    "contacts",
+    "remarks",
+]
+
+segment_key_priority = [
+    "segment_id",
+    "name",
+    "start",
+    "end",
+    "kinds",
+    "irregularities",
+]
+
+
+def sort_keys(d, priority=None):
+    # this requires python >= 3.7 as it relies on dictionary order
+    if priority is None:
+        priority = []
+    ordered_keys = [k for k in priority if k in d] + \
+                   [k for k in sorted(d.keys()) if k not in priority]
+    return dict([(k, d[k]) for k in ordered_keys])
+
+
 def _main():
     import argparse
 
@@ -17,14 +50,17 @@ def _main():
     for filename in args.infiles:
         with open(filename) as f:
             flight = yaml.load(f, Loader=yaml.SafeLoader)
-        all_flights[flight["platform"]][flight["flight_id"]] = flight
+        all_flights[flight["platform"]][flight["flight_id"]] = sort_keys(
+                {**flight, "segments": list(sorted((sort_keys(seg, segment_key_priority) for seg in flight["segments"]),
+                                                   key=lambda seg: seg["start"]))},
+                flight_key_priority)
 
     if args.outfile:
         outfile = open(args.outfile, "w")
     else:
         outfile = sys.stdout
 
-    yaml.dump(dict(all_flights.items()), outfile)
+    yaml.dump(sort_keys(dict(all_flights.items())), outfile, allow_unicode=True, sort_keys=False)
 
     return 0
 


### PR DESCRIPTION
The order in the compiled yaml files doesn't have a semantic meaning,
but it should be kept mostly fixed to simplify the search for changes.
Befor this change the order has been alphabetically, which is not very
friendly to a human reader. This change list a few manually selected
keys in a preferred order and uses this order for sorting. Additional
keys may also be present and are appended in alphabetical order (as
before).

closes #27 