### PR TITLE
Use nicknames instead of names

### DIFF
--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200119.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200119.yaml
@@ -1,4 +1,4 @@
-name: RF01
+nickname: Silke's Coming
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0119

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200122.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200122.yaml
@@ -1,4 +1,4 @@
-name: RF02
+nickname: Fish Wake
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0122

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200124.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200124.yaml
@@ -1,4 +1,4 @@
-name: RF03
+nickname: ColdPools
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0124

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200126.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200126.yaml
@@ -1,4 +1,4 @@
-name: RF04
+nickname: Manfred's Escape
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0126

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200128.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200128.yaml
@@ -1,4 +1,4 @@
-name: RF05
+nickname: Sugar
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0128

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200130.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200130.yaml
@@ -1,4 +1,4 @@
-name: RF06
+nickname: Mario's Snail
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0130

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200131.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200131.yaml
@@ -1,4 +1,4 @@
-name: RF07
+nickname: Grains for Geet
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0131

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200202.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200202.yaml
@@ -1,4 +1,4 @@
-name: RF08
+nickname: Felix's Clover
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0202

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200205.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200205.yaml
@@ -1,4 +1,4 @@
-name: RF09
+nickname: Bernhard's Bicycle
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0205

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200207.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200207.yaml
@@ -1,4 +1,4 @@
-name: RF10
+nickname: Raphaela's Flower
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0207

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200209.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200209.yaml
@@ -1,4 +1,4 @@
-name: RF11
+nickname: Sabrina's Towers
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0209

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200211.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200211.yaml
@@ -1,4 +1,4 @@
-name: RF12
+nickname: Marek's Intermezzo
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0211

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200213.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200213.yaml
@@ -1,4 +1,4 @@
-name: RF13
+nickname: Jessica's Veils
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0213

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200215.yaml
@@ -1,4 +1,4 @@
-name: RF14
+nickname: Under Cover
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0215

--- a/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200218.yaml
+++ b/flight_phase_files/HALO/EUREC4A_HALO_Flight-Segments_20200218.yaml
@@ -1,4 +1,4 @@
-name: RF15
+nickname: Silke's Going
 mission: EUREC4A
 platform: HALO
 flight_id: HALO-0218


### PR DESCRIPTION
The use of RFxx flight names has always been confusing and ambiguous.
The topic has been discussed already during the field campaign and we
concluded that we offically want to refer to flights only by their
flight_id. Still, those RF-names have made it until this place and keep
popping up here and there. This commit get's rid of those in the
official flight listing. However, as it might be fun to have another
name for each flight, we've got (hopefully less ambiguous) nicknames for each.

I don't know what other aircraft operators think about those RF-names, so I didn't change them there.